### PR TITLE
Add minimal dashboard site and Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,0 +1,34 @@
+name: Deploy Dashboard to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - refactor/ci-pipeline-fixes
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Basketball Prediction Dashboard</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+        color: #f8fafc;
+      }
+      main {
+        text-align: center;
+        padding: 2.5rem 3rem;
+        border-radius: 1.5rem;
+        background: rgba(15, 23, 42, 0.85);
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+        max-width: 540px;
+      }
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: 2rem;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        font-size: 1.05rem;
+        color: #cbd5f5;
+      }
+      a {
+        color: #38bdf8;
+        font-weight: 600;
+        text-decoration: none;
+        border-bottom: 2px solid transparent;
+        transition: border-color 0.2s ease;
+      }
+      a:hover,
+      a:focus {
+        border-color: currentColor;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Basketball Prediction Dashboard</h1>
+      <p>CI pipeline is running. Website is live.</p>
+      <a href="https://github.com/Alex-2911/Basketball_prediction">View the GitHub repository</a>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a minimal static landing page for the project so the CI pipeline can demonstrate a live dashboard.
- Deploy the static site to GitHub Pages automatically from the `refactor/ci-pipeline-fixes` branch.
- Keep the site simple (plain HTML + CSS) with no build step or JS frameworks.

### Description
- Added a static site at `web/index.html` with the title "Basketball Prediction Dashboard", subtitle text, and a link to the repository.
- Added a GitHub Actions workflow at `.github/workflows/deploy-dashboard.yml` that triggers on `workflow_dispatch` and `push` to `refactor/ci-pipeline-fixes`.
- Workflow permissions set to `contents: read`, `pages: write`, and `id-token: write`, and it uses `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4` to upload and deploy the `web` directory.
- Committed the added files with the message `Add minimal dashboard site + Pages deploy workflow`.

### Testing
- Served the static site locally with `python -m http.server -d /workspace/Basketball_prediction/web` and the server started successfully.
- Ran an automated Playwright script to load `http://127.0.0.1:8000/` and capture a screenshot, which completed and produced `artifacts/dashboard.png`.
- Verified the new files are present and the git commit succeeded (commit created successfully).
- Note: the GitHub Actions Pages workflow has not been executed on GitHub from this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695424eeb8208331b8ccdc2c88a382a9)