### PR TITLE
Standardize Script 5 dashboard outputs

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -75,6 +75,9 @@ jobs:
             2026/output/LightGBM/bet_shortlist_*.csv
             2026/output/LightGBM/home_win_rates_sorted_*.csv
             2026/output/LightGBM/betting_summary_*.xlsx
+            2026/output/LightGBM/local_matched_games_*.csv
+            2026/output/LightGBM/metrics_snapshot.json
+            2026/output/LightGBM/strategy_params.txt
             2026/output/LightGBM/Kelly/*.csv
           if-no-files-found: warn
 

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -930,6 +930,12 @@ def resolve_output_dir(base_dir: str, prediction_dir: str) -> Path:
             out_dir.mkdir(parents=True, exist_ok=True)
             return out_dir
 
+    base_path = Path(base_dir)
+    out_dir = base_path / "2026" / "output" / "LightGBM"
+    if out_dir.exists() or base_path.exists():
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return out_dir
+
     out_dir = Path(prediction_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     return out_dir
@@ -1092,12 +1098,12 @@ def write_strategy_params(
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / "strategy_params.txt"
     lines = [
-        f"as_of_date: {as_of_date}",
-        f"min_ev: {float(min_ev)}",
-        f"stake: {float(stake)}",
+        f"as_of_date={as_of_date}",
+        f"min_ev={float(min_ev)}",
+        f"stake={float(stake)}",
     ]
     for key in sorted(params_used.keys()):
-        lines.append(f"{key}: {params_used[key]}")
+        lines.append(f"{key}={params_used[key]}")
     out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     logging.info("Saved strategy params to %s", out_path)
     return out_path
@@ -1108,8 +1114,6 @@ def export_local_matched_games_settled(
     *,
     output_dir: Path,
     as_of_date: str,
-    expected_count: Optional[int],
-    expected_profit: Optional[float],
 ) -> Path | None:
     if export_df is None or export_df.empty:
         logging.info("No settled local matched games to export.")
@@ -1119,21 +1123,37 @@ def export_local_matched_games_settled(
     export_path = output_dir / f"local_matched_games_{as_of_date}.csv"
     export_df.to_csv(export_path, index=False, encoding="utf-8")
 
-    if expected_count is not None and len(export_df) != expected_count:
+    logging.info("Exported settled local matched games to %s (%d rows).", export_path, len(export_df))
+    return export_path
+
+
+def check_metrics_snapshot_consistency(export_df: pd.DataFrame, output_dir: Path) -> None:
+    snapshot_path = output_dir / "metrics_snapshot.json"
+    if not snapshot_path.exists():
+        return
+
+    try:
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        print("WARNING: metrics_snapshot.json could not be parsed for consistency checks.")
+        return
+
+    realized = snapshot.get("realized", {})
+    expected_count = realized.get("count")
+    expected_profit = realized.get("profit_sum")
+
+    if expected_count is not None and len(export_df) != int(expected_count):
         print(
-            "WARN: local_matched_games rows mismatch "
+            "WARNING: local_matched_games row count mismatch "
             f"(expected {expected_count}, got {len(export_df)})."
         )
     if expected_profit is not None:
         pnl_sum = float(export_df["pnl"].sum())
         if abs(pnl_sum - float(expected_profit)) > 0.01:
             print(
-                "WARN: local_matched_games pnl sum mismatch "
-                f"(expected {expected_profit:.2f}, got {pnl_sum:.2f})."
+                "WARNING: local_matched_games pnl sum mismatch "
+                f"(expected {float(expected_profit):.2f}, got {pnl_sum:.2f})."
             )
-
-    logging.info("Exported settled local matched games to %s (%d rows).", export_path, len(export_df))
-    return export_path
 
 
 def choose_params_fair_lastN(
@@ -1482,9 +1502,9 @@ def main() -> None:
         matched_export_df,
         output_dir=out_dir,
         as_of_date=as_of_date,
-        expected_count=snapshot["realized"]["count"],
-        expected_profit=snapshot["realized"]["profit_sum"],
     )
+    if matched_export_df is not None and not matched_export_df.empty:
+        check_metrics_snapshot_consistency(matched_export_df, out_dir)
 
     upcoming_filter_eval_and_reasons(
         upcoming_df=df_future,


### PR DESCRIPTION
### Motivation
- Ensure Script 5 emits the same dashboard-ready artifacts used by Hoops-Insight in a consistent output folder layout.
- Produce settled local matched games CSV, a machine-readable metrics snapshot, and daily strategy params in a predictable format.
- Add soft consistency checks so KPI snapshot and exported settled trades are cross-validated with warnings instead of failing runs.

### Description
- Updated `resolve_output_dir` to prefer `SOURCE_ROOT/output/LightGBM` and fall back to `<base_dir>/2026/output/LightGBM` before using the prediction directory. 
- Changed `write_strategy_params` to emit `key=value` lines in `strategy_params.txt` and ensured it is written to the unified output directory. 
- Added `check_metrics_snapshot_consistency` to compare `metrics_snapshot.json` (`realized.count` and `realized.profit_sum`) against the exported `local_matched_games_{AS_OF_DATE}.csv` and print `WARNING:` messages on mismatches, and call it after exporting settled games. 
- Simplified `export_local_matched_games_settled` signature and updated the workflow `.github/workflows/4_calculate_betting_statistics_2026.yml` to upload `local_matched_games_*.csv`, `metrics_snapshot.json`, and `strategy_params.txt` as artifacts. 

### Testing
- No automated tests were executed for this change during the rollout. 
- Changes were committed and the workflow artifact list updated to include the new files for CI-run verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6f50441c83319dfacf63b0f97da6)