### PR TITLE
Run Script 5 as Python strategy, unify EV export, and update last_run trace

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -876,15 +876,15 @@ def print_local_matched_games(best_subset_window, window_n: int):
     df["prob_iso"] = df[ISO_COL]
     df["odds_1"] = df[HOME_ODDS_COL]
     df["win"] = df[RESULT_COL].astype(int)
-    if "ev_per_100" not in df.columns:
-        if "EV_€_per_100" in df.columns:
-            df["ev_per_100"] = df["EV_€_per_100"]
+    if "EV_€_per_100" not in df.columns:
+        if "ev_per_100" in df.columns:
+            df["EV_€_per_100"] = df["ev_per_100"]
         elif "EV_per_100" in df.columns:
-            df["ev_per_100"] = df["EV_per_100"]
+            df["EV_€_per_100"] = df["EV_per_100"]
 
     cols = [
         "date", "home_team", "away_team", "home_win_rate", "prob_iso",
-        "prob_used", "odds_1", "ev_per_100", "win", "pnl",
+        "prob_used", "odds_1", "EV_€_per_100", "win", "pnl",
     ]
     for c in cols:
         if c not in df.columns:
@@ -899,7 +899,7 @@ def print_local_matched_games(best_subset_window, window_n: int):
             "prob_iso": 3,
             "prob_used": 3,
             "odds_1": 3,
-            "ev_per_100": 2,
+            "EV_€_per_100": 2,
             "pnl": 1,
         })
         .to_string(index=False)
@@ -978,25 +978,25 @@ def prepare_local_matched_export(best_subset_window: pd.DataFrame, stake: float)
     if "pnl" not in df.columns and "pnl_flat" in df.columns:
         df["pnl"] = df["pnl_flat"]
 
-    if "ev_per_100" not in df.columns:
-        if "EV_€_per_100" in df.columns:
-            df["ev_per_100"] = df["EV_€_per_100"]
+    if "EV_€_per_100" not in df.columns:
+        if "ev_per_100" in df.columns:
+            df["EV_€_per_100"] = df["ev_per_100"]
         elif "EV_per_100" in df.columns:
-            df["ev_per_100"] = df["EV_per_100"]
+            df["EV_€_per_100"] = df["EV_per_100"]
         elif "prob_used" in df.columns and HOME_ODDS_COL in df.columns:
             df = _compute_ev_per_100(
                 df,
                 prob_col="prob_used",
                 odds_col=HOME_ODDS_COL,
                 stake_for_ev=100.0,
-                dst="ev_per_100",
+                dst="EV_€_per_100",
             )
 
     df["home_win_rate"] = pd.to_numeric(df["home_win_rate"], errors="coerce")
     df["prob_iso"] = pd.to_numeric(df["prob_iso"], errors="coerce")
     df["prob_used"] = pd.to_numeric(df["prob_used"], errors="coerce")
     df["odds_1"] = pd.to_numeric(df["odds_1"], errors="coerce")
-    df["ev_per_100"] = pd.to_numeric(df["ev_per_100"], errors="coerce")
+    df["EV_€_per_100"] = pd.to_numeric(df["EV_€_per_100"], errors="coerce")
     df["win"] = pd.to_numeric(df["win"], errors="coerce")
     if "pnl" not in df.columns and df["win"].notna().any() and df["odds_1"].notna().any():
         df["pnl"] = np.where(
@@ -1022,7 +1022,7 @@ def prepare_local_matched_export(best_subset_window: pd.DataFrame, stake: float)
         "prob_iso",
         "prob_used",
         "odds_1",
-        "ev_per_100",
+        "EV_€_per_100",
         "win",
         "pnl",
         "stake",
@@ -1047,7 +1047,7 @@ def build_metrics_snapshot(
     profit_sum = float(export_df["pnl"].sum()) if realized_count > 0 else 0.0
     roi = profit_sum / (realized_count * float(stake)) if realized_count > 0 else 0.0
     win_rate = float(export_df["win"].mean()) if realized_count > 0 else 0.0
-    ev_col = "ev_per_100" if "ev_per_100" in export_df.columns else "EV_€_per_100"
+    ev_col = "EV_€_per_100" if "EV_€_per_100" in export_df.columns else "ev_per_100"
     ev_mean = float(export_df[ev_col].mean()) if realized_count > 0 else 0.0
     if np.isnan(ev_mean):
         ev_mean = 0.0
@@ -1149,17 +1149,67 @@ def check_metrics_snapshot_consistency(export_df: pd.DataFrame, output_dir: Path
     expected_profit = realized.get("profit_sum")
 
     if expected_count is not None and len(export_df) != int(expected_count):
-        print(
-            "WARNING: local_matched_games row count mismatch "
-            f"(expected {expected_count}, got {len(export_df)})."
+        logging.warning(
+            "local_matched_games row count mismatch (expected %s, got %s).",
+            expected_count,
+            len(export_df),
         )
     if expected_profit is not None:
         pnl_sum = float(export_df["pnl"].sum())
         if abs(pnl_sum - float(expected_profit)) > 0.01:
-            print(
-                "WARNING: local_matched_games pnl sum mismatch "
-                f"(expected {float(expected_profit):.2f}, got {pnl_sum:.2f})."
+            logging.warning(
+                "local_matched_games pnl sum mismatch (expected %.2f, got %.2f).",
+                float(expected_profit),
+                pnl_sum,
             )
+
+
+def update_last_run_trace(
+    export_df: pd.DataFrame,
+    export_path: Path | None,
+    snapshot: dict,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    trace_path = repo_root / "public" / "data" / "last_run.json"
+    trace_path.parent.mkdir(parents=True, exist_ok=True)
+
+    trace_data: dict = {}
+    if trace_path.exists():
+        try:
+            trace_data = json.loads(trace_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logging.warning("Unable to parse existing last_run.json; overwriting.")
+
+    resolved_path = str(export_path.resolve()) if export_path is not None else ""
+    expected_rows = snapshot.get("realized", {}).get("count")
+    settled_rows = int(len(export_df)) if export_df is not None else 0
+    profit_sum = float(export_df["pnl"].sum()) if export_df is not None and not export_df.empty else 0.0
+
+    ytd_df = export_df.copy() if export_df is not None else pd.DataFrame()
+    if not ytd_df.empty and "date" in ytd_df.columns:
+        ytd_df["date"] = pd.to_datetime(ytd_df["date"], errors="coerce")
+        ytd_df = ytd_df[ytd_df["date"].dt.year == 2026]
+    net_pl = float(ytd_df["pnl"].sum()) if not ytd_df.empty else 0.0
+
+    bankroll_start = 1000.0
+    bankroll_end = bankroll_start + net_pl
+
+    trace_data.update(
+        {
+            "local_matched_games_source": resolved_path,
+            "local_matched_games_rows_expected": int(expected_rows)
+            if expected_rows is not None
+            else settled_rows,
+            "local_matched_games_rows_settled": settled_rows,
+            "local_matched_games_profit_sum_table": round(profit_sum, 2),
+            "bankroll_2026_start": round(bankroll_start, 2),
+            "bankroll_2026_net_pl": round(net_pl, 2),
+            "bankroll_2026_end": round(bankroll_end, 2),
+        }
+    )
+
+    trace_path.write_text(json.dumps(trace_data, indent=2), encoding="utf-8")
+    logging.info("Updated trace info at %s", trace_path)
 
 
 def choose_params_fair_lastN(
@@ -1504,13 +1554,14 @@ def main() -> None:
         stake=FLAT_STAKE,
         output_dir=out_dir,
     )
-    export_local_matched_games_settled(
+    export_path = export_local_matched_games_settled(
         local_matched_df,
         output_dir=out_dir,
         as_of_date=as_of_date,
     )
     if local_matched_df is not None and not local_matched_df.empty:
         check_metrics_snapshot_consistency(local_matched_df, out_dir)
+    update_last_run_trace(local_matched_df, export_path, snapshot)
 
     upcoming_filter_eval_and_reasons(
         upcoming_df=df_future,

--- a/scripts/run_script5.py
+++ b/scripts/run_script5.py
@@ -7,7 +7,33 @@ import sys
 from pathlib import Path
 
 
-NOTEBOOK_NAME = "_5. isotonic_calibrated_betting_engine_daily_driver.ipynb"
+SCRIPT5_NAME = "5_Isotonic_based_betting_strategy_2026.py"
+
+
+def resolve_script5_path() -> Path:
+    explicit = os.getenv("SCRIPT5_PATH")
+    if explicit:
+        path = Path(explicit)
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        if path.exists():
+            return path
+        raise FileNotFoundError(f"SCRIPT5_PATH gesetzt aber nicht gefunden: {path}")
+
+    locations = [
+        Path.cwd() / SCRIPT5_NAME,
+        Path.cwd() / "src" / SCRIPT5_NAME,
+        Path.cwd() / "scripts" / SCRIPT5_NAME,
+        Path.cwd() / "2026" / "src" / SCRIPT5_NAME,
+    ]
+    for path in locations:
+        if path.exists():
+            return path
+
+    matches = sorted(Path.cwd().rglob("*.py"))
+    raise FileNotFoundError(
+        f"Script 5 nicht gefunden. cwd={Path.cwd()} Kandidaten={matches[:20]}"
+    )
 
 
 def resolve_source_root() -> Path:
@@ -18,33 +44,6 @@ def resolve_source_root() -> Path:
     if workspace:
         return Path(workspace) / "2026"
     return Path("2026")
-
-
-def resolve_notebook_path() -> Path:
-    notebook_path = Path(NOTEBOOK_NAME)
-    if notebook_path.exists():
-        return notebook_path
-    repo_root = Path(__file__).resolve().parents[1]
-    fallback = repo_root / NOTEBOOK_NAME
-    if fallback.exists():
-        return fallback
-    raise FileNotFoundError(f"Notebook not found: {NOTEBOOK_NAME}")
-
-
-def run_notebook(notebook_path: Path) -> None:
-    cmd = [
-        sys.executable,
-        "-m",
-        "jupyter",
-        "nbconvert",
-        "--to",
-        "notebook",
-        "--execute",
-        "--inplace",
-        "--ExecutePreprocessor.timeout=1800",
-        str(notebook_path),
-    ]
-    subprocess.run(cmd, check=True)
 
 
 def assert_outputs(source_root: Path) -> None:
@@ -70,8 +69,9 @@ def main() -> int:
     os.environ.setdefault("SOURCE_ROOT", str(source_root))
     os.environ.setdefault("N_WINDOW", "200")
 
-    notebook_path = resolve_notebook_path()
-    run_notebook(notebook_path)
+    script_path = resolve_script5_path()
+    print(f"Using Script 5: {script_path}")
+    subprocess.run([sys.executable, str(script_path)], check=True)
     assert_outputs(source_root)
     return 0
 

--- a/scripts/script5_export_outputs.py
+++ b/scripts/script5_export_outputs.py
@@ -17,7 +17,7 @@ REQUIRED_COLUMNS = [
     "prob_iso",
     "prob_used",
     "odds_1",
-    "ev_per_100",
+    "EV_€_per_100",
     "win",
     "pnl",
     "stake",
@@ -83,9 +83,14 @@ def prepare_export_df(raw_df: pd.DataFrame, default_stake: float) -> pd.DataFram
     df["pnl"] = pd.to_numeric(df.get("pnl"), errors="coerce")
     df["stake"] = pd.to_numeric(df.get("stake"), errors="coerce")
 
-    if "ev_per_100" not in df.columns:
-        df["ev_per_100"] = compute_ev_per_100(df["prob_used"], df["odds_1"])
-    df["ev_per_100"] = pd.to_numeric(df["ev_per_100"], errors="coerce")
+    if "EV_€_per_100" not in df.columns:
+        if "ev_per_100" in df.columns:
+            df["EV_€_per_100"] = df["ev_per_100"]
+        elif "EV_per_100" in df.columns:
+            df["EV_€_per_100"] = df["EV_per_100"]
+        else:
+            df["EV_€_per_100"] = compute_ev_per_100(df["prob_used"], df["odds_1"])
+    df["EV_€_per_100"] = pd.to_numeric(df["EV_€_per_100"], errors="coerce")
 
     df = df.dropna(subset=["win", "pnl"]).copy()
     if df.empty:
@@ -113,7 +118,7 @@ def build_metrics_snapshot(
     profit_sum = float(export_df["pnl"].sum()) if realized_count > 0 else 0.0
     roi = profit_sum / (realized_count * float(stake)) if realized_count > 0 else 0.0
     win_rate = float(export_df["win"].mean()) if realized_count > 0 else 0.0
-    ev_mean = float(export_df["ev_per_100"].mean()) if realized_count > 0 else 0.0
+    ev_mean = float(export_df["EV_€_per_100"].mean()) if realized_count > 0 else 0.0
 
     sharpe_style = 0.0
     if realized_count > 1:


### PR DESCRIPTION
### Motivation
- Replace notebook execution with a runner that executes the Python Strategy-5 file and prefer `SCRIPT5_PATH` when set for CI reliability.
- Ensure the dashboard backend reads a single source-of-truth CSV with only settled local matched games and exact columns.
- Use a consistent `EV_€_per_100` column across exports and avoid crashes on snapshot mismatches by logging warnings instead.
- Add a 2026 YTD bankroll summary (flat 100 stake, 1000 deposit) into the last-run trace for the UI/monitoring.

### Description
- Add `scripts/run_script5.py` which resolves `SCRIPT5_PATH` (with relative/absolute handling) and falls back to a short search for `5_Isotonic_based_betting_strategy_2026.py`, then runs it with `sys.executable` and asserts required outputs under `SOURCE_ROOT/output/LightGBM`.
- Update `2026/src/5_Isotonic_based_betting_strategy_2026.py` to standardize on `EV_€_per_100` for display/export, export only settled rows to `local_matched_games_{AS_OF_DATE}.csv`, log snapshot consistency mismatches (no crash), and return the export path.
- Add `update_last_run_trace(...)` which writes/merges trace info to `public/data/last_run.json` including `local_matched_games_source`, expected/settled rows, profit sum, and 2026 bankroll entries (`bankroll_2026_start`, `bankroll_2026_net_pl`, `bankroll_2026_end`).
- Align `scripts/script5_export_outputs.py` to prefer/produce `EV_€_per_100` and compute it if missing.

### Testing
- Executed the updated runner which runs the Python strategy and produces outputs under `2026/output/LightGBM` (success).
- Verified the exported `local_matched_games_{AS_OF_DATE}.csv` exists and contains only settled rows with the exact columns `date, home_team, away_team, home_win_rate, prob_iso, prob_used, odds_1, EV_€_per_100, win, pnl, stake` (success).
- Confirmed `metrics_snapshot.json` is written and snapshot consistency mismatches are emitted as warnings rather than raising exceptions (no crash).
- Confirmed `public/data/last_run.json` was updated with `local_matched_games_source`, settled row counts and bankroll 2026 summary (end balance €930.00) as part of the trace update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d77f3b0688331a6993ed077646888)