### PR TITLE
Fix DATE_COL initialization and avoid shadowing in Script 5

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -1428,6 +1428,15 @@ def main() -> None:
     # 1) LOAD COMBINED
     df_all = load_combined_df(pred_dir, target_ymd)
 
+    DATE_COL = "game_date"
+    if DATE_COL not in df_all.columns:
+        if "date" in df_all.columns:
+            df_all[DATE_COL] = df_all["date"]
+        else:
+            raise KeyError(f"Neither '{DATE_COL}' nor 'date' exists. Columns: {list(df_all.columns)}")
+
+    df_all = _ensure_datetime(df_all, DATE_COL)
+
     # 1b) COMPUTE HOME WIN RATES (before we merge future games)
     hwr_path = compute_home_win_rates(df_all, target_ymd, pred_dir)
 
@@ -1537,15 +1546,15 @@ def main() -> None:
     matched_df = matched_window_df.copy() if matched_window_df is not None else pd.DataFrame()
 
     # --- COLUMN RESOLVER (robust for matched_df/local_matched_df schemas) ---
-    DATE_COL = "date" if "date" in matched_df.columns else ("game_date" if "game_date" in matched_df.columns else None)
-    PROB_COL = (
+    BR_DATE_COL = "date" if "date" in matched_df.columns else ("game_date" if "game_date" in matched_df.columns else None)
+    BR_PROB_COL = (
         "prob_iso"
         if "prob_iso" in matched_df.columns
         else ("iso_proba_home_win" if "iso_proba_home_win" in matched_df.columns else ("prob_used" if "prob_used" in matched_df.columns else None))
     )
-    ODDS_COL = "odds_1" if "odds_1" in matched_df.columns else ("closing_home_odds" if "closing_home_odds" in matched_df.columns else None)
+    BR_ODDS_COL = "odds_1" if "odds_1" in matched_df.columns else ("closing_home_odds" if "closing_home_odds" in matched_df.columns else None)
 
-    missing = [name for name, col in [("DATE_COL", DATE_COL), ("PROB_COL", PROB_COL), ("ODDS_COL", ODDS_COL)] if col is None]
+    missing = [name for name, col in [("BR_DATE_COL", BR_DATE_COL), ("BR_PROB_COL", BR_PROB_COL), ("BR_ODDS_COL", BR_ODDS_COL)] if col is None]
     if missing:
         raise KeyError(
             "Missing required columns for bankroll calc. "
@@ -1565,21 +1574,21 @@ def main() -> None:
     flat_stake = 100        # 100€ flat stake
 
     for _, row in last_200_df.iterrows():
-        prob = row[PROB_COL]
-        odds = row[ODDS_COL]
+        prob = row[BR_PROB_COL]
+        odds = row[BR_ODDS_COL]
         bankroll_window += flat_stake * (prob * (odds - 1) - (1 - prob))
 
     # --- BANKROLL SECTION 2: 2026 YTD ONLY ---
-    if pd.api.types.is_datetime64_any_dtype(historical_df[DATE_COL]):
-        ytd_2026_df = historical_df[historical_df[DATE_COL].dt.year == 2026].copy()
+    if pd.api.types.is_datetime64_any_dtype(historical_df[BR_DATE_COL]):
+        ytd_2026_df = historical_df[historical_df[BR_DATE_COL].dt.year == 2026].copy()
     else:
-        ytd_2026_df = historical_df[historical_df[DATE_COL].astype(str).str.startswith("2026")].copy()
+        ytd_2026_df = historical_df[historical_df[BR_DATE_COL].astype(str).str.startswith("2026")].copy()
     bankroll_2026 = 1000  # 1000€ Deposit
     flat_stake_2026 = 100  # 100€ flat stake
 
     for _, row in ytd_2026_df.iterrows():
-        prob = row[PROB_COL]
-        odds = row[ODDS_COL]
+        prob = row[BR_PROB_COL]
+        odds = row[BR_ODDS_COL]
         bankroll_2026 += flat_stake_2026 * (prob * (odds - 1) - (1 - prob))
 
     # Force result adjustment (per requirement)


### PR DESCRIPTION
### Motivation
- Prevent an `UnboundLocalError` when `_ensure_datetime(df_past, DATE_COL)` is called because `DATE_COL` was not always defined in `main()`.
- Ensure the canonical date column is consistently `game_date` and created from `date` when needed.
- Avoid accidentally shadowing the global `DATE_COL` inside the bankroll resolver which led to local-variable collisions.
- Keep bankroll calculations robust to different matched_df schemas while not modifying the global `DATE_COL` usage.

### Description
- Initialize `DATE_COL` in `main()` immediately after loading predictions by setting `DATE_COL = "game_date"`, creating it from `date` if missing, and normalizing with `df_all = _ensure_datetime(df_all, DATE_COL)`.
- Rename the local bankroll resolver variables to `BR_DATE_COL`, `BR_PROB_COL`, and `BR_ODDS_COL` so they do not shadow the global `DATE_COL`.
- Update the bankroll calculations and YTD filtering to use `BR_DATE_COL`, `BR_PROB_COL`, and `BR_ODDS_COL` consistently.
- Add a descriptive `KeyError` if neither `game_date` nor `date` exist in the loaded dataframe to fail fast with column information.

### Testing
- No automated tests were executed as part of this change.
- A quick code search was performed to confirm the new `BR_` names are used in the bankroll sections and `DATE_COL` is initialized in `main()`.
- Changes were committed to `2026/src/5_Isotonic_based_betting_strategy_2026.py` and saved.
- Manual run/CI was not performed in this PR (no automated test results to report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb5faaf148331b08e1704c763d151)