### PR TITLE
Upload metrics snapshot artifact after Script 5

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -65,6 +65,13 @@ jobs:
           SOURCE_ROOT=$GITHUB_WORKSPACE/2026 python scripts/run_script5.py
           echo "=== Script 5 finished ==="
 
+      - name: Upload metrics snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-snapshot
+          path: Basketball_prediction/2026/output/LightGBM/metrics_snapshot.json
+          if-no-files-found: error
+
       - name: Upload Script 5 outputs
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation

- Ensure the `metrics_snapshot.json` produced by Script 5 is published as a standalone GitHub Actions artifact for easier access and retention.
- Make the metrics upload fail loudly when the file is missing by using `if-no-files-found: error` so missing outputs are detected.
- Add the artifact step immediately after the Script 5 run to capture the file as soon as it is produced.

### Description

- Added a new step `Upload metrics snapshot` to `.github/workflows/4_calculate_betting_statistics_2026.yml` placed after the Script 5 run.
- The step uses `actions/upload-artifact@v4` with `name: metrics-snapshot` and `path: Basketball_prediction/2026/output/LightGBM/metrics_snapshot.json`.
- The step sets `if-no-files-found: error` to surface missing artifact files as an error.
- The existing `Upload Script 5 outputs` artifact step was left in place (it still lists `2026/output/LightGBM/metrics_snapshot.json`).

### Testing

- No automated tests were run because this change only modifies a GitHub Actions workflow file and does not alter runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec368e25c8331ae94167360700022)