### PR TITLE
Pin LightGBM to 4.x (>=4.3.0,<5) to support Python 3.11 wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.24.4
 beautifulsoup4==4.11.2
 selenium==4.7.0
 webdriver-manager==4.0.2
-lightgbm==3.3.5
+lightgbm>=4.3.0,<5
 scikit-learn==1.2.2
 xlsxwriter==3.1.2
 lxml==5.4.0


### PR DESCRIPTION
### Motivation
- Fix GitHub Actions dependency install failures on Python 3.11 by using a LightGBM release that provides Py3.11 wheels.
- Keep other dependency pins unchanged to minimize risk.

### Description
- Updated `requirements.txt` replacing `lightgbm==3.3.5` with `lightgbm>=4.3.0,<5`.
- Searched the codebase for `lightgbm` usage (found imports in `2026/src/3_predict_games_hybrid_2026.py` and `2025/src/3_lightgbm.py`) and verified the common `LGBMClassifier` training API is still used, so no code changes were required.
- Committed the requirements change.

### Testing
- No automated tests or CI jobs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec5ef2798833199d59236174b59e6)