### PR TITLE
Pin numpy to 1.26.4 and matplotlib to 3.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools==80.1.0
 pandas==2.2.3
-numpy==1.24.4
+numpy==1.26.4
 beautifulsoup4==4.11.2
 selenium==4.7.0
 webdriver-manager==4.0.2
@@ -8,7 +8,7 @@ lightgbm>=4.3.0,<5
 scikit-learn==1.2.2
 xlsxwriter==3.1.2
 lxml==5.4.0
-matplotlib>=3.0
+matplotlib==3.8.4
 html5lib==1.1
 
 


### PR DESCRIPTION
### Motivation
- Fix pip install failures on GitHub Actions with Python 3.11 by updating overly-strict dependency pins.  
- Ensure a stable `matplotlib` version is used to avoid auto-pulling incompatible `3.10.x` releases.  
- Preserve the existing `lightgbm` compatibility range to avoid runtime/compatibility regressions.  

### Description
- Update `numpy` pin from `numpy==1.24.4` to `numpy==1.26.4` in `requirements.txt`.  
- Replace the broad `matplotlib>=3.0` constraint with an explicit `matplotlib==3.8.4`.  
- Keep the `lightgbm>=4.3.0,<5` line and all other entries unchanged.  

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec8f12ab08331a05746886fe269a8)