### PR TITLE
Fix metrics snapshot artifact upload path

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -65,11 +65,16 @@ jobs:
           SOURCE_ROOT=$GITHUB_WORKSPACE/2026 python scripts/run_script5.py
           echo "=== Script 5 finished ==="
 
+      - name: Verify metrics snapshot output
+        run: |
+          ls -la 2026/output/LightGBM | head -n 50
+          test -f 2026/output/LightGBM/metrics_snapshot.json
+
       - name: Upload metrics snapshot
         uses: actions/upload-artifact@v4
         with:
           name: metrics-snapshot
-          path: Basketball_prediction/2026/output/LightGBM/metrics_snapshot.json
+          path: 2026/output/LightGBM/metrics_snapshot.json
           if-no-files-found: error
 
       - name: Upload Script 5 outputs


### PR DESCRIPTION
### Motivation

- The artifact upload referenced `Basketball_prediction/2026/...` which does not match the runner workspace layout and caused `actions/upload-artifact` to miss the file.
- Add a quick verification before upload to fail early and make debugging easier.

### Description

- Update `.github/workflows/4_calculate_betting_statistics_2026.yml` to set the `metrics-snapshot` artifact `path` to `2026/output/LightGBM/metrics_snapshot.json` instead of `Basketball_prediction/2026/output/LightGBM/metrics_snapshot.json`.
- Add a `Verify metrics snapshot output` step that runs `ls -la 2026/output/LightGBM | head -n 50` and `test -f 2026/output/LightGBM/metrics_snapshot.json` immediately before the upload.
- Leave the other artifact uploads and the commit/push step unchanged.

### Testing

- No automated CI workflows were run for this change since it is a workflow-only update.
- Local repository commands used were `git add` and `git commit`, but no workflow execution results were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ecc7c16708331bb8cf2f5c672bb10)