### PR TITLE
Support multiple prediction dirs and resilient date selection for Script 4 & 5

### DIFF
--- a/2026/src/4_calculate_betting_statistics_2026.py
+++ b/2026/src/4_calculate_betting_statistics_2026.py
@@ -52,6 +52,7 @@ DATA_DIR = paths['DATA_DIR']
 STAT_DIR = paths['STAT_DIR']
 target_folder = paths['NEXT_GAME_DIR']
 directory_path = paths['PREDICTION_DIR']
+prediction_dirs = paths['PREDICTION_DIRS']
 
 
 def find_most_recent_prediction_file():
@@ -66,17 +67,16 @@ def find_most_recent_prediction_file():
 
         logging.info(f"Checking prediction file for date: {date_str}")
         filename = f"nba_games_predict_{date_str}.csv"
-        file_path = os.path.join(directory_path, filename)
-
-        if os.path.isfile(file_path):
-            file_found = True
-            logging.info(f"Found prediction file for {date_str}: {file_path}")
-            return [file_path], date_str
-        else:
-            days_back += 1
+        for prediction_dir in prediction_dirs:
+            file_path = os.path.join(prediction_dir, filename)
+            if os.path.isfile(file_path):
+                file_found = True
+                logging.info(f"Found prediction file for {date_str}: {file_path}")
+                return file_path, date_str, prediction_dir
+        days_back += 1
 
     logging.warning("No prediction file found in the last %d days.", MAX_DAYS_BACK)
-    return None, None
+    return None, None, None
 
 
 def find_most_recent_statistics_file():
@@ -94,7 +94,7 @@ def find_most_recent_statistics_file():
         return None
 
 
-def process_prediction_file(predict_file, last_prediction):
+def process_prediction_file(predict_file, last_prediction, prediction_dir):
     """
     Process the prediction file and update the combined predictions.
 
@@ -110,14 +110,14 @@ def process_prediction_file(predict_file, last_prediction):
         return None
 
     # Read prediction file; use default encoding and convert decimal comma to period
-    predict_df = pd.read_csv(predict_file[0])
+    predict_df = pd.read_csv(predict_file)
     # Normalize decimal columns in odds
     for col in ['odds 1', 'odds 2']:
         if col in predict_df.columns:
             predict_df[col] = predict_df[col].astype(str).str.replace(',', '.').astype(float)
 
     # Path for combined data (one file per prediction date)
-    combined_file_path = os.path.join(directory_path, f'combined_nba_predictions_acc_{last_prediction}.csv')
+    combined_file_path = os.path.join(prediction_dir, f'combined_nba_predictions_acc_{last_prediction}.csv')
     # Load existing combined file or create new
     try:
         combined_df = pd.read_csv(combined_file_path)
@@ -134,7 +134,7 @@ def process_prediction_file(predict_file, last_prediction):
     return combined_df
 
 
-def update_betting_statistics(combined_df, most_recent_date):
+def update_betting_statistics(combined_df, most_recent_date, prediction_dir):
     """
     Update betting statistics with actual game results.
 
@@ -188,7 +188,7 @@ def update_betting_statistics(combined_df, most_recent_date):
     logging.info(f"Accuracy for home_team_prob <= 0.40: {low_conf_home:.2%}")
 
     # Save updated DataFrame with today's date
-    save_path = os.path.join(directory_path, f'combined_nba_predictions_acc_{today_str_format}.csv')
+    save_path = os.path.join(prediction_dir, f'combined_nba_predictions_acc_{today_str_format}.csv')
     # Drop unnamed columns and NaNs
     season_df.drop(columns=['Unnamed: 8'], errors='ignore', inplace=True)
     season_df.dropna(inplace=True)
@@ -200,13 +200,13 @@ def update_betting_statistics(combined_df, most_recent_date):
 def main():
     """Main execution function for updating betting statistics."""
     # Find most recent prediction file
-    predict_file, last_prediction = find_most_recent_prediction_file()
+    predict_file, last_prediction, prediction_dir = find_most_recent_prediction_file()
     if not predict_file:
         print("No recent prediction file found.")
         return
 
     # Process prediction file
-    combined_df = process_prediction_file(predict_file, last_prediction)
+    combined_df = process_prediction_file(predict_file, last_prediction, prediction_dir)
     if combined_df is None:
         print("Failed to process prediction file.")
         return
@@ -218,7 +218,7 @@ def main():
         return
 
     # Update betting statistics
-    updated_df = update_betting_statistics(combined_df, most_recent_date)
+    updated_df = update_betting_statistics(combined_df, most_recent_date, prediction_dir)
     if updated_df is not None:
         print("Betting statistics updated successfully.")
     else:

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -140,6 +140,43 @@ def to_float_series(s: pd.Series) -> pd.Series:
     )
 
 
+def _extract_date_from_filename(filename: str, prefix: str) -> Optional[str]:
+    if not filename.startswith(prefix) or not filename.endswith(".csv"):
+        return None
+    date_str = filename[len(prefix):-4]
+    try:
+        datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        return None
+    return date_str
+
+
+def resolve_dated_file(
+    pred_dirs: list[str],
+    prefix: str,
+    target_ymd: str,
+) -> Tuple[Optional[Path], Optional[str]]:
+    for pred_dir in pred_dirs:
+        candidate = Path(pred_dir) / f"{prefix}{target_ymd}.csv"
+        if candidate.exists():
+            return candidate, target_ymd
+
+    dated_candidates: list[tuple[datetime, Path, str]] = []
+    for pred_dir in pred_dirs:
+        for candidate in Path(pred_dir).glob(f"{prefix}*.csv"):
+            date_str = _extract_date_from_filename(candidate.name, prefix)
+            if not date_str:
+                continue
+            dated_candidates.append((datetime.strptime(date_str, "%Y-%m-%d"), candidate, date_str))
+
+    if not dated_candidates:
+        return None, None
+
+    latest_date, latest_path, latest_str = max(dated_candidates, key=lambda item: item[0])
+    logging.info("Falling back to latest %s file (%s).", prefix.rstrip("_"), latest_date.date())
+    return latest_path, latest_str
+
+
 def load_combined_df(pred_dir: str, ymd_str: str) -> pd.DataFrame:
     """
     Load combined_nba_predictions_acc_YYYY-MM-DD.csv and guarantee that
@@ -240,17 +277,15 @@ def load_combined_df(pred_dir: str, ymd_str: str) -> pd.DataFrame:
 
 def merge_today_predictions(
     df_all: pd.DataFrame,
-    pred_dir: str,
-    ymd_str: str,
+    today_pred_path: Optional[Path],
     today_date,
 ) -> pd.DataFrame:
     """
     Merge in upcoming games from nba_games_predict_YYYY-MM-DD.csv
     if they are not already present in df_all.
     """
-    today_pred_path = os.path.join(pred_dir, f"nba_games_predict_{ymd_str}.csv")
-    if not os.path.exists(today_pred_path):
-        logging.info("No TODAY_PRED file found (%s) – skipping merge of upcoming games.", today_pred_path)
+    if not today_pred_path or not today_pred_path.exists():
+        logging.info("No TODAY_PRED file found – skipping merge of upcoming games.")
         return df_all
 
     logging.info("Merging upcoming games from %s", today_pred_path)
@@ -942,10 +977,19 @@ def resolve_output_dir(base_dir: str, prediction_dir: str) -> Path:
             return out_dir
 
     base_path = Path(base_dir)
-    out_dir = base_path / "2026" / "LightGBM"
-    if out_dir.exists() or base_path.exists():
-        out_dir.mkdir(parents=True, exist_ok=True)
-        return out_dir
+    primary_out_dir = base_path / "2026" / "LightGBM"
+    if primary_out_dir.exists():
+        primary_out_dir.mkdir(parents=True, exist_ok=True)
+        return primary_out_dir
+
+    fallback_out_dir = base_path / "2026" / "output" / "LightGBM"
+    if fallback_out_dir.exists():
+        fallback_out_dir.mkdir(parents=True, exist_ok=True)
+        return fallback_out_dir
+
+    if base_path.exists():
+        primary_out_dir.mkdir(parents=True, exist_ok=True)
+        return primary_out_dir
 
     out_dir = Path(prediction_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -1578,7 +1622,24 @@ def main() -> None:
     tomorrow_date = (target_dt + timedelta(days=1)).date()
 
     paths = get_directory_paths()
-    pred_dir = paths["PREDICTION_DIR"]
+    pred_dirs = paths["PREDICTION_DIRS"]
+
+    combined_path, combined_date = resolve_dated_file(
+        pred_dirs,
+        "combined_nba_predictions_acc_",
+        target_ymd,
+    )
+    if not combined_path or not combined_date:
+        raise FileNotFoundError("No combined_nba_predictions_acc_*.csv files found in prediction dirs.")
+
+    if combined_date != target_ymd:
+        logging.info("No combined file for %s; using latest available %s.", target_ymd, combined_date)
+        target_ymd = combined_date
+        target_dt = datetime.strptime(target_ymd, "%Y-%m-%d")
+        today_date = target_dt.date()
+        tomorrow_date = (target_dt + timedelta(days=1)).date()
+
+    pred_dir = str(combined_path.parent)
     out_dir = resolve_output_dir(paths["BASE_DIR"], pred_dir)
     kelly_dir = os.path.join(pred_dir, "Kelly")
     os.makedirs(kelly_dir, exist_ok=True)
@@ -1599,7 +1660,22 @@ def main() -> None:
     hwr_path = compute_home_win_rates(df_all, target_ymd, pred_dir)
 
     # 2) MERGE TODAY'S PREDICTIONS (if any) TO GET FUTURE GAMES INTO df_all
-    df_all = merge_today_predictions(df_all, pred_dir, target_ymd, today_date)
+    today_pred_path, today_pred_date = resolve_dated_file(
+        pred_dirs,
+        "nba_games_predict_",
+        target_ymd,
+    )
+    if today_pred_path and today_pred_date and today_pred_date != target_ymd:
+        logging.info(
+            "No nba_games_predict file for %s; using latest available %s.",
+            target_ymd,
+            today_pred_date,
+        )
+        pred_date = datetime.strptime(today_pred_date, "%Y-%m-%d").date()
+    else:
+        pred_date = today_date
+
+    df_all = merge_today_predictions(df_all, today_pred_path, pred_date)
 
     # 3) ATTACH HOME WIN RATE (file exists for sure)
     df_all = attach_home_win_rate(df_all, hwr_path)

--- a/2026/src/nba_utils_2026.py
+++ b/2026/src/nba_utils_2026.py
@@ -163,11 +163,18 @@ def get_directory_paths() -> Dict[str, str]:
     base_dir = os.getcwd()  # repo root during Actions
     data_dir = os.path.join(base_dir, "2026", "output", "Gathering_Data")
     lgbm_dir = os.environ.get("LGBM_DIR")
-    prediction_dir = (
-        os.path.abspath(lgbm_dir)
-        if lgbm_dir
-        else os.path.join(base_dir, "2026", "LightGBM")
-    )
+    if lgbm_dir:
+        prediction_dir = os.path.abspath(lgbm_dir)
+        prediction_dirs = [prediction_dir]
+    else:
+        prediction_dirs = [
+            os.path.join(base_dir, "2026", "LightGBM"),
+            os.path.join(base_dir, "2026", "output", "LightGBM"),
+        ]
+        prediction_dir = next(
+            (path for path in prediction_dirs if os.path.exists(path)),
+            prediction_dirs[0],
+        )
 
     paths = {
         "BASE_DIR": base_dir,
@@ -181,10 +188,15 @@ def get_directory_paths() -> Dict[str, str]:
         ),
         "NEXT_GAME_DIR": os.path.join(data_dir, "Next_Game"),
         "PREDICTION_DIR": prediction_dir,
+        "PREDICTION_DIRS": prediction_dirs,
     }
 
     for p in paths.values():
-        os.makedirs(p, exist_ok=True)
+        if isinstance(p, str):
+            os.makedirs(p, exist_ok=True)
+
+    for pred_path in prediction_dirs:
+        os.makedirs(pred_path, exist_ok=True)
 
     return paths
 


### PR DESCRIPTION
### Motivation
- Allow the 2026 pipeline to operate with either `2026/LightGBM` or `2026/output/LightGBM` layouts so CI / local runs both work without manual changes. 
- Ensure Script 4 writes outputs next to whichever prediction folder it found. 
- Make Script 5 robust when "today" files are missing by falling back to the latest available dated files.

### Description
- Add `PREDICTION_DIRS` to `get_directory_paths()` and prefer an existing path from `["2026/LightGBM", "2026/output/LightGBM"]`, while preserving support for `LGBM_DIR` environment variable in `2026/src/nba_utils_2026.py`.
- Create prediction directories when missing and return both a selected `PREDICTION_DIR` and the full `PREDICTION_DIRS` list for callers.
- Update Script 4 (`2026/src/4_calculate_betting_statistics_2026.py`) to search all `PREDICTION_DIRS` when locating `nba_games_predict_YYYY-MM-DD.csv`, return the found path and use the located prediction directory when reading/writing combined prediction files.
- Update Script 5 (`2026/src/5_Isotonic_based_betting_strategy_2026.py`) to: resolve combined/prediction files across all `PREDICTION_DIRS`, fall back to the latest available dated file if the target date file is not present, accept a `Path` for today's prediction when merging, and prefer the primary/fallback output directory layout when resolving `LightGBM` output.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669b9adde4833193b872b3a9cf2f9b)