### PR TITLE
Add canonical bet ledger migration and daily maintenance

### DIFF
--- a/2026/scripts/maintain_bet_log_flat_live.py
+++ b/2026/scripts/maintain_bet_log_flat_live.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -22,18 +23,17 @@ LEDGER_COLUMNS = [
     "date",
     "home_team",
     "away_team",
-    "home_win_rate",
-    "prob_iso",
-    "prob_used",
-    "odds_1",
-    "EV_€_per_100",
     "stake",
-    "potential_profit_if_win",
+    "odds",
+    "pick",
     "status",
-    "win",
+    "won",
     "pnl",
-    "settled_at",
-    "game_key",
+    "prob_used",
+    "ev_per_100",
+    "created_at_utc",
+    "settled_at_utc",
+    "source",
 ]
 
 
@@ -167,7 +167,7 @@ def _prepare_combined(df: pd.DataFrame) -> pd.DataFrame:
         combined["home_win_rate"] = np.nan
 
     combined["prob_used"] = combined["prob_iso"].clip(PROB_CLIP_LO, PROB_CLIP_HI)
-    combined["EV_€_per_100"] = (
+    combined["ev_per_100"] = (
         combined["prob_used"] * (combined["odds_1"] - 1)
         - (1 - combined["prob_used"])
     ) * 100
@@ -187,31 +187,67 @@ def _prepare_combined(df: pd.DataFrame) -> pd.DataFrame:
     return combined
 
 
+def _ensure_columns(df: pd.DataFrame) -> pd.DataFrame:
+    for column in LEDGER_COLUMNS:
+        if column not in df.columns:
+            df[column] = np.nan
+    return df
+
+
+def _normalize_status(series: pd.Series) -> pd.Series:
+    return series.astype(str).str.strip().str.upper()
+
+
 def _load_ledger(path: Path) -> pd.DataFrame:
     if not path.exists():
         return pd.DataFrame(columns=LEDGER_COLUMNS)
 
     ledger = pd.read_csv(path)
 
-    if "win" not in ledger.columns and "won" in ledger.columns:
-        ledger["win"] = ledger["won"]
+    rename_map = {
+        "odds_1": "odds",
+        "stake_flat": "stake",
+        "EV_€_per_100": "ev_per_100",
+        "win": "won",
+        "settled_at": "settled_at_utc",
+    }
+    ledger = ledger.rename(columns={k: v for k, v in rename_map.items() if k in ledger.columns})
 
-    if "pnl" not in ledger.columns and "pnl_flat" in ledger.columns:
-        ledger["pnl"] = ledger["pnl_flat"]
+    if "odds" not in ledger.columns and "closing_home_odds" in ledger.columns:
+        ledger["odds"] = ledger["closing_home_odds"]
 
-    if "stake" not in ledger.columns:
-        if "stake_flat" in ledger.columns:
-            ledger["stake"] = ledger["stake_flat"]
-        else:
-            ledger["stake"] = STAKE
-
-    for column in LEDGER_COLUMNS:
-        if column not in ledger.columns:
-            ledger[column] = np.nan
+    ledger = _ensure_columns(ledger)
 
     ledger["date"] = _normalize_date(ledger["date"])
     ledger["home_team"] = _normalize_team(ledger["home_team"])
     ledger["away_team"] = _normalize_team(ledger["away_team"])
+
+    if ledger["stake"].isna().any():
+        ledger["stake"] = ledger["stake"].fillna(STAKE)
+
+    if ledger["pick"].isna().any():
+        ledger["pick"] = ledger["pick"].fillna("HOME")
+
+    ledger["won"] = _coerce_win(ledger["won"]).astype("float")
+
+    status = _normalize_status(ledger["status"].fillna(""))
+    needs_status = status.eq("")
+    status = status.mask(needs_status, np.where(ledger["won"].notna(), "SETTLED", "PENDING"))
+    ledger["status"] = status
+
+    needs_pnl = ledger["pnl"].isna() & ledger["won"].notna()
+    if needs_pnl.any():
+        odds = pd.to_numeric(ledger["odds"], errors="coerce")
+        stake = pd.to_numeric(ledger["stake"], errors="coerce").fillna(STAKE)
+        ledger.loc[needs_pnl, "pnl"] = np.where(
+            ledger.loc[needs_pnl, "won"] == 1,
+            stake.loc[needs_pnl] * (odds.loc[needs_pnl] - 1),
+            -stake.loc[needs_pnl],
+        )
+
+    ledger["settled_at_utc"] = ledger["settled_at_utc"].astype("string")
+    ledger["created_at_utc"] = ledger["created_at_utc"].astype("string")
+
     ledger["game_key"] = (
         ledger["date"].fillna("")
         + "_"
@@ -220,27 +256,29 @@ def _load_ledger(path: Path) -> pd.DataFrame:
         + ledger["away_team"].fillna("")
     )
 
-    if "status" in ledger.columns:
-        status_filled = ledger["status"].fillna("")
-    else:
-        status_filled = ""
+    return ledger
 
-    needs_status = status_filled.astype(str).str.strip().eq("")
-    if needs_status.any():
-        ledger.loc[needs_status, "status"] = np.where(
-            ledger.loc[needs_status, "win"].notna(), "SETTLED", "PENDING"
-        )
 
-    settled_mask = ledger["status"].astype(str).str.upper() == "SETTLED"
-    missing_settled_at = settled_mask & ledger["settled_at"].isna()
-    if missing_settled_at.any():
-        ledger.loc[missing_settled_at, "settled_at"] = ledger.loc[
-            missing_settled_at, "date"
-        ]
+def _dedupe_ledger(ledger: pd.DataFrame) -> pd.DataFrame:
+    if ledger.empty:
+        return ledger
 
-    ledger["settled_at"] = ledger["settled_at"].astype("string")
+    status_rank = _normalize_status(ledger["status"]).map({"PENDING": 0, "SETTLED": 1}).fillna(0)
+    settled_ts = pd.to_datetime(ledger["settled_at_utc"], errors="coerce")
+    created_ts = pd.to_datetime(ledger["created_at_utc"], errors="coerce")
 
-    return ledger[LEDGER_COLUMNS]
+    ledger = ledger.assign(
+        _status_rank=status_rank,
+        _settled_ts=settled_ts,
+        _created_ts=created_ts,
+    ).sort_values([
+        "_status_rank",
+        "_settled_ts",
+        "_created_ts",
+    ])
+
+    ledger = ledger.drop_duplicates(subset=["game_key"], keep="last")
+    return ledger.drop(columns=["_status_rank", "_settled_ts", "_created_ts"])
 
 
 def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.DataFrame:
@@ -252,31 +290,56 @@ def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.DataFra
         & (upcoming["odds_1"] >= ODDS_MIN)
         & (upcoming["odds_1"] <= ODDS_MAX)
         & (upcoming["prob_used"] >= PROB_MIN)
-        & (upcoming["EV_€_per_100"] > MIN_EV)
+        & (upcoming["ev_per_100"] > MIN_EV)
     ].copy()
 
     new_rows = qualifiers[~qualifiers["game_key"].isin(existing_keys)].copy()
     if new_rows.empty:
         return ledger
 
-    new_rows["stake"] = STAKE
-    new_rows["potential_profit_if_win"] = new_rows["stake"] * (
-        new_rows["odds_1"] - 1
-    )
-    new_rows["status"] = "PENDING"
-    new_rows["win"] = np.nan
-    new_rows["pnl"] = np.nan
-    new_rows["settled_at"] = np.nan
+    now_utc = datetime.now(timezone.utc).isoformat()
 
-    append_df = new_rows[LEDGER_COLUMNS]
-    return pd.concat([ledger, append_df], ignore_index=True)
+    new_rows["stake"] = STAKE
+    new_rows["odds"] = new_rows["odds_1"]
+    new_rows["pick"] = "HOME"
+    new_rows["status"] = "PENDING"
+    new_rows["won"] = np.nan
+    new_rows["pnl"] = np.nan
+    new_rows["created_at_utc"] = now_utc
+    new_rows["settled_at_utc"] = np.nan
+    new_rows["source"] = "auto"
+
+    append_df = new_rows[
+        [
+            "date",
+            "home_team",
+            "away_team",
+            "stake",
+            "odds",
+            "pick",
+            "status",
+            "won",
+            "pnl",
+            "prob_used",
+            "ev_per_100",
+            "created_at_utc",
+            "settled_at_utc",
+            "source",
+            "game_key",
+        ]
+    ]
+
+    combined_ledger = pd.concat([ledger, append_df], ignore_index=True)
+    return combined_ledger
 
 
 def _settle_pending_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.DataFrame:
     results = combined[combined["win"].notna()].set_index("game_key")
-    pending_mask = ledger["status"].astype(str).str.upper() == "PENDING"
+    pending_mask = _normalize_status(ledger["status"]) == "PENDING"
     if not pending_mask.any():
         return ledger
+
+    now_utc = datetime.now(timezone.utc).isoformat()
 
     for idx in ledger[pending_mask].index:
         game_key = ledger.at[idx, "game_key"]
@@ -285,14 +348,14 @@ def _settle_pending_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.Dat
 
         win = int(results.at[game_key, "win"])
         stake = float(ledger.at[idx, "stake"]) if pd.notna(ledger.at[idx, "stake"]) else STAKE
-        odds = float(ledger.at[idx, "odds_1"]) if pd.notna(ledger.at[idx, "odds_1"]) else np.nan
+        odds = float(ledger.at[idx, "odds"]) if pd.notna(ledger.at[idx, "odds"]) else np.nan
         if pd.isna(odds):
             continue
 
         ledger.at[idx, "status"] = "SETTLED"
-        ledger.at[idx, "win"] = win
+        ledger.at[idx, "won"] = win
         ledger.at[idx, "pnl"] = stake * (odds - 1) if win == 1 else -stake
-        ledger.at[idx, "settled_at"] = results.at[game_key, "date"]
+        ledger.at[idx, "settled_at_utc"] = now_utc
 
     return ledger
 
@@ -308,14 +371,16 @@ def main() -> None:
     ledger = _load_ledger(ledger_path)
     ledger = _settle_pending_bets(ledger, combined)
     ledger = _append_new_bets(ledger, combined)
+    ledger = _dedupe_ledger(ledger)
 
     ledger = ledger.sort_values(["date", "home_team", "away_team"], na_position="last")
 
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
     export_path.parent.mkdir(parents=True, exist_ok=True)
 
-    ledger.to_csv(ledger_path, index=False, encoding="utf-8")
-    ledger.to_csv(export_path, index=False, encoding="utf-8")
+    ledger_output = _ensure_columns(ledger)[LEDGER_COLUMNS]
+    ledger_output.to_csv(ledger_path, index=False, encoding="utf-8")
+    ledger_output.to_csv(export_path, index=False, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/2026/scripts/migrate_bet_log_flat_live_schema.py
+++ b/2026/scripts/migrate_bet_log_flat_live_schema.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+
+PROB_CLIP_LO = 0.35
+PROB_CLIP_HI = 0.80
+STAKE_DEFAULT = 100
+
+LEDGER_COLUMNS = [
+    "date",
+    "home_team",
+    "away_team",
+    "stake",
+    "odds",
+    "pick",
+    "status",
+    "won",
+    "pnl",
+    "prob_used",
+    "ev_per_100",
+    "created_at_utc",
+    "settled_at_utc",
+    "source",
+]
+
+
+def _normalize_date(series: pd.Series) -> pd.Series:
+    return pd.to_datetime(series, errors="coerce", format="mixed").dt.strftime(
+        "%Y-%m-%d"
+    )
+
+
+def _normalize_team(series: pd.Series) -> pd.Series:
+    return series.astype(str).str.strip().str.upper().str.replace(" ", "", regex=False)
+
+
+def _resolve_first(columns: Iterable[str], candidates: Iterable[str]) -> str | None:
+    for name in candidates:
+        if name in columns:
+            return name
+    return None
+
+
+def _coerce_win(series: pd.Series) -> pd.Series:
+    numeric = pd.to_numeric(series, errors="coerce")
+    normalized = series.astype(str).str.strip().str.lower()
+    win_map = {
+        "1": 1,
+        "true": 1,
+        "w": 1,
+        "win": 1,
+        "home": 1,
+        "0": 0,
+        "false": 0,
+        "l": 0,
+        "loss": 0,
+        "away": 0,
+    }
+    mapped = normalized.map(win_map)
+    if numeric.notna().any():
+        numeric_converted = numeric.where(numeric.isna(), (numeric >= 1).astype(int))
+        return numeric_converted.fillna(mapped)
+    return mapped
+
+
+def _ensure_columns(df: pd.DataFrame) -> pd.DataFrame:
+    for column in LEDGER_COLUMNS:
+        if column not in df.columns:
+            df[column] = np.nan
+    return df
+
+
+def _normalize_status(series: pd.Series) -> pd.Series:
+    return series.astype(str).str.strip().str.upper()
+
+
+def _dedupe_ledger(ledger: pd.DataFrame) -> pd.DataFrame:
+    if ledger.empty:
+        return ledger
+
+    status_rank = _normalize_status(ledger["status"]).map({"PENDING": 0, "SETTLED": 1}).fillna(0)
+    settled_ts = pd.to_datetime(ledger["settled_at_utc"], errors="coerce")
+    created_ts = pd.to_datetime(ledger["created_at_utc"], errors="coerce")
+
+    ledger = ledger.assign(
+        _status_rank=status_rank,
+        _settled_ts=settled_ts,
+        _created_ts=created_ts,
+    ).sort_values([
+        "_status_rank",
+        "_settled_ts",
+        "_created_ts",
+    ])
+
+    ledger = ledger.drop_duplicates(subset=["game_key"], keep="last")
+    return ledger.drop(columns=["_status_rank", "_settled_ts", "_created_ts"])
+
+
+def migrate(input_path: Path, output_path: Path) -> None:
+    df = pd.read_csv(input_path)
+
+    rename_map = {
+        "odds_1": "odds",
+        "stake_flat": "stake",
+        "EV_€_per_100": "ev_per_100",
+        "win": "won",
+        "settled_at": "settled_at_utc",
+    }
+    df = df.rename(columns={k: v for k, v in rename_map.items() if k in df.columns})
+
+    if "odds" not in df.columns and "closing_home_odds" in df.columns:
+        df["odds"] = df["closing_home_odds"]
+
+    if "prob_used" not in df.columns and "prob_iso" in df.columns:
+        df["prob_used"] = pd.to_numeric(df["prob_iso"], errors="coerce").clip(
+            PROB_CLIP_LO, PROB_CLIP_HI
+        )
+
+    df = _ensure_columns(df)
+
+    df["date"] = _normalize_date(df["date"])
+    df["home_team"] = _normalize_team(df["home_team"])
+    df["away_team"] = _normalize_team(df["away_team"])
+
+    if df["stake"].isna().any():
+        df["stake"] = df["stake"].fillna(STAKE_DEFAULT)
+
+    if df["pick"].isna().any():
+        df["pick"] = df["pick"].fillna("HOME")
+
+    df["won"] = _coerce_win(df["won"]).astype("float")
+
+    status = _normalize_status(df["status"].fillna(""))
+    needs_status = status.eq("")
+    status = status.mask(needs_status, np.where(df["won"].notna(), "SETTLED", "PENDING"))
+    df["status"] = status
+
+    prob_iso_col = _resolve_first(df.columns, ["prob_iso", "probability", "prob"])
+    if prob_iso_col:
+        prob_iso = pd.to_numeric(df[prob_iso_col], errors="coerce")
+        bad_prob = prob_iso > 1
+    else:
+        bad_prob = pd.Series(False, index=df.index)
+
+    prob_used = pd.to_numeric(df["prob_used"], errors="coerce")
+    bad_prob_used = prob_used > 1
+
+    df = df[~(bad_prob | bad_prob_used)].copy()
+
+    needs_pnl = df["pnl"].isna() & df["won"].notna()
+    if needs_pnl.any():
+        odds = pd.to_numeric(df["odds"], errors="coerce")
+        stake = pd.to_numeric(df["stake"], errors="coerce").fillna(STAKE_DEFAULT)
+        df.loc[needs_pnl, "pnl"] = np.where(
+            df.loc[needs_pnl, "won"] == 1,
+            stake.loc[needs_pnl] * (odds.loc[needs_pnl] - 1),
+            -stake.loc[needs_pnl],
+        )
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+    df["created_at_utc"] = df["created_at_utc"].fillna(now_utc)
+
+    df["game_key"] = (
+        df["date"].fillna("")
+        + "_"
+        + df["home_team"].fillna("")
+        + "_"
+        + df["away_team"].fillna("")
+    )
+
+    df = _dedupe_ledger(df)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df = df.sort_values(["date", "home_team", "away_team"], na_position="last")
+    df[LEDGER_COLUMNS].to_csv(output_path, index=False, encoding="utf-8")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    default_input = repo_root / "2026" / "output" / "LightGBM" / "bet_log_flat_live.csv"
+    default_fallback = repo_root / "2026" / "bet_log" / "bet_log_flat_live.csv"
+    default_output = repo_root / "2026" / "bet_log" / "bet_log_flat_live.csv"
+
+    parser = argparse.ArgumentParser(
+        description="Migrate bet_log_flat_live.csv to the canonical schema."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=default_input if default_input.exists() else default_fallback,
+        help="Path to the existing bet_log_flat_live.csv to migrate.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=default_output,
+        help="Destination path for the migrated ledger.",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        raise FileNotFoundError(f"Input bet log not found: {args.input}")
+
+    migrate(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -1106,8 +1106,10 @@ def build_settled_bets(
     bet_date_col = _resolve_first_col(bet_df, ["date", "game_date"])
     bet_home_col = _resolve_first_col(bet_df, ["home_team", "home", "team_home"])
     bet_away_col = _resolve_first_col(bet_df, ["away_team", "away", "team_away"])
-    odds_col = _resolve_first_col(bet_df, ["odds_1", "odds", "home_odds", "closing_home_odds"])
+    odds_col = _resolve_first_col(bet_df, ["odds", "odds_1", "home_odds", "closing_home_odds"])
     stake_col = _resolve_first_col(bet_df, ["stake", "stake_eur", "stake_flat"])
+    status_col = _resolve_first_col(bet_df, ["status"])
+    won_col = _resolve_first_col(bet_df, ["won", "win"])
 
     if not bet_date_col or not bet_home_col or not bet_away_col:
         return pd.DataFrame()
@@ -1126,24 +1128,41 @@ def build_settled_bets(
     else:
         bet_df["stake"] = np.nan
 
-    results_date_col = _resolve_first_col(results, ["date", DATE_COL, "game_date"])
-    results_home_col = _resolve_first_col(results, ["home_team", "home"])
-    results_away_col = _resolve_first_col(results, ["away_team", "away"])
-    results_win_col = _resolve_first_col(results, ["home_team_won", "win", "result"])
+    if status_col:
+        bet_df["status"] = _normalize_text(bet_df[status_col]).str.upper()
+        bet_df = bet_df[bet_df["status"] == "SETTLED"].copy()
+        if bet_df.empty:
+            return pd.DataFrame()
 
-    if not results_date_col or not results_home_col or not results_away_col or not results_win_col:
-        return pd.DataFrame()
+    if won_col:
+        bet_df["win"] = pd.to_numeric(bet_df[won_col], errors="coerce")
+    else:
+        bet_df["win"] = np.nan
 
-    results["date"] = _normalize_date(results, results_date_col)
-    results["home_team"] = _normalize_text(results[results_home_col])
-    results["away_team"] = _normalize_text(results[results_away_col])
-    results["win"] = pd.to_numeric(results[results_win_col], errors="coerce")
+    merged = bet_df
+    if merged["win"].isna().any():
+        results_date_col = _resolve_first_col(results, ["date", DATE_COL, "game_date"])
+        results_home_col = _resolve_first_col(results, ["home_team", "home"])
+        results_away_col = _resolve_first_col(results, ["away_team", "away"])
+        results_win_col = _resolve_first_col(results, ["home_team_won", "win", "result"])
 
-    merged = bet_df.merge(
-        results[["date", "home_team", "away_team", "win"]],
-        on=["date", "home_team", "away_team"],
-        how="left",
-    )
+        if not results_date_col or not results_home_col or not results_away_col or not results_win_col:
+            return pd.DataFrame()
+
+        results["date"] = _normalize_date(results, results_date_col)
+        results["home_team"] = _normalize_text(results[results_home_col])
+        results["away_team"] = _normalize_text(results[results_away_col])
+        results["win"] = pd.to_numeric(results[results_win_col], errors="coerce")
+
+        merged = bet_df.merge(
+            results[["date", "home_team", "away_team", "win"]],
+            on=["date", "home_team", "away_team"],
+            how="left",
+            suffixes=("", "_result"),
+        )
+        merged["win"] = merged["win"].fillna(merged.get("win_result"))
+        if "win_result" in merged.columns:
+            merged = merged.drop(columns=["win_result"])
 
     merged = merged.dropna(subset=["stake", "odds_1"]).copy()
 


### PR DESCRIPTION
### Motivation
- Normalize and freeze a canonical bet ledger schema so GitHub runs produce a single, deterministic source of truth for bets and the dashboard can compute settled counts/P&L reliably.
- Clean up today’s uploaded/legacy `bet_log_flat_live.csv` (duplicates, broken probability values, mixed column names) so future maintenance is incremental and deterministic.
- Implement the GitHub equivalent of local maintenance: append new picks, settle against combined results, and export the ledger for the dashboard.

### Description
- Introduce a canonical ledger column set and a migration tool at `2026/scripts/migrate_bet_log_flat_live_schema.py` that renames legacy columns (`odds_1` → `odds`, `stake_flat` → `stake`, `EV_€_per_100` → `ev_per_100`), normalizes dates/teams, filters out invalid probabilities (`prob_iso`/`prob_used` > 1), computes missing `pnl` for settled rows, de-duplicates by `game_key`, and writes to `2026/bet_log/bet_log_flat_live.csv`.
- Replace/extend the maintenance job at `2026/scripts/maintain_bet_log_flat_live.py` to use the canonical columns, load the latest `combined_nba_predictions_iso_*.csv` (fallback to `acc_*`), compute `prob_used`/`ev_per_100`, append new HOME picks with the same filter/score logic as local (`home_win_rate >= 0.55`, `odds` in [2.10,3.10], `prob_used >= 0.40`, `ev_per_100 > -5`), mark new rows as `PENDING`, settle `PENDING` rows deterministically using combined results (set `won`, `pnl`, `status=SETTLED`, `settled_at_utc`), dedupe by `game_key`, add `created_at_utc` and `source="auto"`, and export the ledger copy to `2026/output/LightGBM/bet_log_flat_live.csv`.
- Update settled-bets aggregation to accept the canonical columns in `2026/src/5_Isotonic_based_betting_strategy_2026.py` by preferring `odds`/`won`/`status` when building settled bet stats.

### Testing
- No automated tests were run for this change; changes were authored and committed to the branch and are ready for CI/runner verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f9803d6c8331aa9cce2c1a85f3fe)