### PR TITLE
Use rolling 200-day window for dashboard and parity checks

### DIFF
--- a/scripts/build_dashboard_assets.js
+++ b/scripts/build_dashboard_assets.js
@@ -97,22 +97,17 @@ function formatMinEv(value) {
   return `${num}`;
 }
 
-function determineWindowDates(rows, dateKey) {
-  if (!rows.length) {
-    return { windowStart: null, windowEnd: null, windowRows: [] };
-  }
-  const sorted = rows
-    .map((row) => row[dateKey])
-    .filter(Boolean)
-    .sort();
-  if (!sorted.length) {
-    return { windowStart: null, windowEnd: null, windowRows: [] };
-  }
-  const windowRows = sorted.slice(-REQUIRED_WINDOW_SIZE);
+function formatDateUTC(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function determineWindowDates(windowSize) {
+  const windowEndDate = new Date();
+  const windowStartDate = new Date(windowEndDate);
+  windowStartDate.setUTCDate(windowEndDate.getUTCDate() - (windowSize - 1));
   return {
-    windowStart: windowRows[0],
-    windowEnd: windowRows[windowRows.length - 1],
-    windowRows,
+    windowStart: formatDateUTC(windowStartDate),
+    windowEnd: formatDateUTC(windowEndDate),
   };
 }
 
@@ -131,10 +126,7 @@ function main() {
     throw new Error('No combined_nba_predictions_acc_*.csv found');
   }
   const combinedLatestPath = path.join(outputDir, combinedLatestName);
-  const combinedText = fs.readFileSync(combinedLatestPath, 'utf8');
-  const combinedRows = parseCsv(combinedText);
-  const combinedDateKey = combinedRows[0]?.date ? 'date' : (combinedRows[0]?.game_date ? 'game_date' : 'date');
-  const { windowStart, windowEnd } = determineWindowDates(combinedRows, combinedDateKey);
+  const { windowStart, windowEnd } = determineWindowDates(REQUIRED_WINDOW_SIZE);
 
   const localMatchedLatestName = findLatestFile(outputDir, 'local_matched_games_');
   if (!localMatchedLatestName) {
@@ -163,7 +155,7 @@ function main() {
     `odds ${formatNumber(filterParams.odds_min, 2)}\u2013${formatNumber(filterParams.odds_max, 2)}`,
     `p \u2265 ${formatNumber(filterParams.prob_threshold, 2)}`,
     `EV > ${formatMinEv(filterParams.min_EV)}`,
-    `window ${REQUIRED_WINDOW_SIZE} (${windowStart || '—'} \u2192 ${windowEnd || '—'})`,
+    `window ${REQUIRED_WINDOW_SIZE} days (${windowStart || '—'} \u2192 ${windowEnd || '—'})`,
   ].join(' | ');
 
   const inWindowLocalMatches = localMatchedRows.filter((row) => {

--- a/scripts/validate_dashboard_parity.js
+++ b/scripts/validate_dashboard_parity.js
@@ -45,6 +45,20 @@ function parseCsv(csvText) {
   });
 }
 
+function formatDateUTC(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function computeWindowDates(windowSize) {
+  const windowEndDate = new Date();
+  const windowStartDate = new Date(windowEndDate);
+  windowStartDate.setUTCDate(windowEndDate.getUTCDate() - (windowSize - 1));
+  return {
+    windowStart: formatDateUTC(windowStartDate),
+    windowEnd: formatDateUTC(windowEndDate),
+  };
+}
+
 function ensure(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -53,14 +67,11 @@ function ensure(condition, message) {
 
 function main() {
   const dashboardState = JSON.parse(fs.readFileSync(path.join(dataDir, 'dashboard_state.json'), 'utf8'));
-  const combinedRows = parseCsv(fs.readFileSync(path.join(dataDir, 'combined_latest.csv'), 'utf8'));
   const localMatchedRows = parseCsv(fs.readFileSync(path.join(dataDir, 'local_matched_games_latest.csv'), 'utf8'));
 
-  const combinedDateKey = combinedRows[0]?.date ? 'date' : (combinedRows[0]?.game_date ? 'game_date' : 'date');
-  const combinedDates = combinedRows.map((row) => row[combinedDateKey]).filter(Boolean).sort();
-  const windowRows = combinedDates.slice(-dashboardState.window_size);
-  const computedWindowStart = windowRows[0] || null;
-  const computedWindowEnd = windowRows[windowRows.length - 1] || null;
+  const { windowStart: computedWindowStart, windowEnd: computedWindowEnd } = computeWindowDates(
+    dashboardState.window_size
+  );
 
   ensure(
     computedWindowStart === dashboardState.window_start,

--- a/web/index.html
+++ b/web/index.html
@@ -331,7 +331,7 @@
 
           renderMeta([
             ['As of', dashboardState.as_of_date || '—'],
-            ['Window', `${dashboardState.window_size} games (${dashboardState.window_start || '—'} → ${dashboardState.window_end || '—'})`],
+            ['Window', `${dashboardState.window_size} days (${dashboardState.window_start || '—'} → ${dashboardState.window_end || '—'})`],
             ['Params', `${dashboardState.params_used_label} · ${dashboardState.params_source_label}`],
             ['Strategy as of', dashboardState.strategy_as_of_date || '—'],
             ['Last update (UTC)', dashboardState.last_update_utc],


### PR DESCRIPTION
### Motivation
- Ensure the dashboard window is a deterministic rolling range based on the current date rather than derived from CSV row ordering.
- Make the UI label clear that the window refers to days not games.
- Keep the parity validation logic aligned with the new window calculation so dashboard parity checks remain meaningful.

### Description
- Compute the dashboard window as a rolling range of `REQUIRED_WINDOW_SIZE` days using the current UTC date in `scripts/build_dashboard_assets.js` and replace the previous CSV-derived window logic with `determineWindowDates` and `formatDateUTC`.
- Update the visible filters text and UI metadata to show `days` instead of `games` in `web/index.html`.
- Align the parity validation script by adding `computeWindowDates` and using the `window_size` to compute `window_start`/`window_end` in `scripts/validate_dashboard_parity.js`.
- Keep existing behavior for copying and writing web data assets while switching window computation to date-based logic.

### Testing
- Performed a basic smoke test by serving the `web` directory and running a Playwright script to load `index.html` and capture a screenshot, which completed successfully and produced `artifacts/dashboard.png`.
- No automated unit or integration test suite was executed against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc921a748833186c21aa694b4a670)