### PR TITLE
Respect LGBM_DIR and invoke dashboard asset build from pipeline

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SOURCE_ROOT="${SOURCE_ROOT:-$(pwd)/2026}"
-LGBM_DIR="${LGBM_DIR:-${SOURCE_ROOT}/LightGBM}"
+LGBM_DIR="${LGBM_DIR:-${SOURCE_ROOT}/output/LightGBM}"
 N_WINDOW="${N_WINDOW:-200}"
 
 if [[ ! -d "${SOURCE_ROOT}" ]]; then
@@ -56,3 +56,5 @@ if [[ "$(wc -l < "${matched_path}")" -le 1 ]]; then
 fi
 
 echo "Pipeline outputs ready in ${LGBM_DIR}"
+
+node scripts/build_dashboard_assets.js

--- a/scripts/build_dashboard_assets.js
+++ b/scripts/build_dashboard_assets.js
@@ -5,7 +5,9 @@ const fs = require('fs');
 const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..');
-const outputDir = path.join(repoRoot, '2026', 'output', 'LightGBM');
+const outputDir = path.resolve(
+  process.env.LGBM_DIR || path.join(repoRoot, '2026', 'output', 'LightGBM')
+);
 const webDataDir = path.join(repoRoot, 'web', 'public', 'data');
 
 const REQUIRED_WINDOW_SIZE = 200;


### PR DESCRIPTION
### Motivation
- The dashboard asset builder was using a hard-coded path and did not honor the pipeline output directory set via an environment variable. 
- The pipeline default output path should point to `output/LightGBM` under the source root to match how outputs are organized. 
- The dashboard assets should be generated automatically at the end of the pipeline run so the web UI sees the latest files.

### Description
- Updated `scripts/build_dashboard_assets.js` to resolve `outputDir` from `process.env.LGBM_DIR` when present, falling back to `2026/output/LightGBM`, using `path.resolve` for consistency. 
- Changed `run_pipeline.sh` to default `LGBM_DIR` to `${SOURCE_ROOT}/output/LightGBM` instead of `${SOURCE_ROOT}/LightGBM`. 
- Appended `node scripts/build_dashboard_assets.js` to the end of `run_pipeline.sh` so dashboard data files are copied into `web/public/data` after pipeline validation. 
- Modified files: `scripts/build_dashboard_assets.js` and `run_pipeline.sh`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd201952c83319ca9b8c8cfd5e504)