### PR TITLE
Allow betting stats workflow to run for automated (bot) triggers

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   update_betting_stats_and_shortlist:
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') && github.actor != 'github-actions[bot]' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       STRATEGY_VARIANT: iso


### PR DESCRIPTION
### Motivation
- The betting statistics / shortlist workflow was excluding runs triggered by `github-actions[bot]`, preventing automated prediction runs from progressing to the stats/shortlist step and stopping daily updates.

### Description
- Update the job-level `if` in `.github/workflows/4_calculate_betting_statistics_2026.yml` to remove the `github.actor != 'github-actions[bot]'` guard so the job runs when `github.event_name == 'workflow_dispatch'` or the previous workflow completed successfully.

### Testing
- No automated tests were executed because this is a workflow configuration change only and does not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd4c75c988331bc8a8f6ad87c67b2)