### PR TITLE
Stop ignoring pipeline outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+__pycache__/
+public/
+2026/src/__pycache__/


### PR DESCRIPTION
### Motivation
- Pipeline-generated outputs (notably under `2026/LightGBM` and `2026/output`) need to be committed so updated prediction artifacts can be tracked in the repository.

### Description
- Updated ` .gitignore` to remove ignore entries and negation rules that previously hid the `2026/LightGBM` and `2026/output` directories, leaving only ` .DS_Store`, `__pycache__/`, `public/`, and `2026/src/__pycache__/` on the ignore list.
- This change enables files such as `combined_nba_predictions_acc_*.csv` produced by the pipeline to be added and committed normally.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd7775f9c83319a173d5f7b2755d9)