### PR TITLE
Filter placeholder results in betting stats outputs

### DIFF
--- a/2026/src/4_calculate_betting_statistics_2026.py
+++ b/2026/src/4_calculate_betting_statistics_2026.py
@@ -158,6 +158,14 @@ def update_betting_statistics(combined_df, most_recent_date, prediction_dir):
     season_df['date'] = pd.to_datetime(season_df['date'], errors='coerce')
     daily_games_df['date'] = pd.to_datetime(daily_games_df['date'], errors='coerce')
 
+    # Normalize placeholder results to NaN
+    season_df['result'] = (
+        season_df['result']
+        .astype(str)
+        .str.strip()
+        .replace(["", "0", "1", "nan", "None"], np.nan)
+    )
+
     # Update result column based on actual winners
     for _, row in daily_games_df.iterrows():
         date = row['date']
@@ -168,6 +176,12 @@ def update_betting_statistics(combined_df, most_recent_date, prediction_dir):
             (season_df['home_team'] == winning_team) | (season_df['away_team'] == winning_team)
         )
         season_df.loc[mask, 'result'] = winning_team
+
+    # Keep only rows with valid outcomes
+    season_df = season_df[
+        (season_df['result'] == season_df['home_team'])
+        | (season_df['result'] == season_df['away_team'])
+    ]
 
     # Ensure probabilities are numeric
     season_df['home_team_prob'] = pd.to_numeric(season_df['home_team_prob'], errors='coerce')
@@ -191,7 +205,10 @@ def update_betting_statistics(combined_df, most_recent_date, prediction_dir):
     save_path = os.path.join(prediction_dir, f'combined_nba_predictions_acc_{today_str_format}.csv')
     # Drop unnamed columns and NaNs
     season_df.drop(columns=['Unnamed: 8'], errors='ignore', inplace=True)
-    season_df.dropna(inplace=True)
+    season_df.dropna(
+        subset=["date", "home_team", "away_team", "home_team_prob", "result", "accuracy"],
+        inplace=True,
+    )
     season_df.to_csv(save_path, index=False)
     logging.info(f"Updated betting statistics saved to {save_path}")
     return season_df


### PR DESCRIPTION
### Motivation
- Remove placeholder or malformed `result` values (e.g. `"0"`, `"1"`, empty, `None`) that survive `dropna()` and pollute downstream accuracy and combined files.
- Ensure only games with true outcomes are used for accuracy calculations and exported to prediction accuracy files.
- Narrow the `dropna` behavior so only required columns for accuracy are required, avoiding accidental retention of placeholder rows.

### Description
- In `update_betting_statistics()` normalized `result` by casting to string, stripping, and replacing `"", "0", "1", "nan", "None"` with `np.nan` via `season_df['result'] = ...`.
- After applying actual game winners, filtered `season_df` to keep only rows where `result` equals `home_team` or `away_team`.
- Replaced the broad `season_df.dropna(inplace=True)` with a targeted `dropna(subset=["date", "home_team", "away_team", "home_team_prob", "result", "accuracy"])` so only essential columns are required for export.
- Kept the existing numeric coercion for `home_team_prob` and accuracy computation unchanged and continue to drop the `Unnamed: 8` column if present.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e93844cec8331b3f7fe59388b53cc)