### PR TITLE
ci: guard combined_latest placeholder outcomes

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -140,6 +140,35 @@ jobs:
           echo "DIFF AFTER NODE vs AFTER SCRIPT5 (if any):"
           git diff -- web/public/data/local_matched_games_latest.csv || true
 
+      - name: Guard: combined_latest.csv must not contain placeholder outcomes
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import csv
+          from pathlib import Path
+
+          p = Path("web/public/data/combined_latest.csv")
+          if not p.exists():
+              raise SystemExit("Missing web/public/data/combined_latest.csv")
+
+          total = 0
+          bad = 0
+
+          with p.open(newline="", encoding="utf-8") as f:
+              r = csv.DictReader(f, delimiter="\t")
+              for row in r:
+                  total += 1
+                  res = (row.get("result_raw") or row.get("result") or "").strip()
+                  htw = (row.get("home_team_won") or "").strip()
+                  if res in {"0", "1"} and htw == "":
+                      bad += 1
+
+          if bad:
+              raise SystemExit(f"Found {bad}/{total} placeholder outcome rows in combined_latest.csv.")
+          print(f"OK: checked {total} rows; no placeholder outcomes.")
+          PY
+
       - name: Show git status before commit
         shell: bash
         run: |
@@ -175,7 +204,6 @@ jobs:
           git push origin 2026
 
           
-
 
 
 


### PR DESCRIPTION
### Motivation
- Prevent regressions where `web/public/data/combined_latest.csv` contains placeholder outcomes (`result`/`result_raw` == `"0"`/`"1"`) with missing `home_team_won`, which causes dashboard stats/filters to be incorrect.

### Description
- Add a workflow guard step to `.github/workflows/4_calculate_betting_statistics_2026.yml` named `Guard: combined_latest.csv must not contain placeholder outcomes` that runs a small Python check over the tab-delimited `web/public/data/combined_latest.csv` and fails the job if any row has `result` or `result_raw` in `{"0","1"}` while `home_team_won` is empty.

### Testing
- No automated tests were executed for this PR because it is a workflow-only change; the guard will be validated when the Step 4/5 GitHub Actions workflow runs in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e957836948331a82d7678b698ad60)