### PR TITLE
Add effective_params and params_sources to dashboard_state.json

### DIFF
--- a/scripts/build_dashboard_assets.js
+++ b/scripts/build_dashboard_assets.js
@@ -402,6 +402,27 @@ function main() {
     active_filters_text: activeFiltersText,
     params_used_label: 'Historical',
     params_source_label: metricsSnapshot.params_used_type || 'Unknown',
+    effective_params: {
+      as_of_date: asOfDate,
+      window_size: REQUIRED_WINDOW_SIZE,
+      home_win_rate_threshold:
+        paramsUsed.home_win_rate_threshold ?? strategyParams.home_win_rate_threshold ?? null,
+      odds_min: paramsUsed.odds_min ?? strategyParams.odds_min ?? null,
+      odds_max: paramsUsed.odds_max ?? strategyParams.odds_max ?? null,
+      prob_threshold: paramsUsed.prob_threshold ?? strategyParams.prob_threshold ?? null,
+      min_ev: minEV !== undefined ? minEV : (strategyParams.min_ev ?? null),
+      stake: strategyParams.stake ?? null,
+      n_trades: strategyParams.n_trades ?? null,
+      profit_eur: strategyParams['profit_€'] ?? strategyParams.profit_eur ?? null,
+      roi_pct: strategyParams['roi_%'] ?? strategyParams.roi_pct ?? null,
+    },
+    params_sources: {
+      metrics_snapshot: 'metrics_snapshot.json',
+      strategy_params_json: fs.existsSync(path.join(webDataDir, 'strategy_params.json'))
+        ? 'strategy_params.json'
+        : null,
+      strategy_params_txt: fs.existsSync(strategyParamsTxtPath) ? 'strategy_params.txt' : null,
+    },
     strategy_as_of_date: strategyAsOfDate,
     last_update_utc: new Date().toISOString(),
     source_files: {


### PR DESCRIPTION
### Motivation
- Ensure the deployed dashboard can deterministically render the "Params used" line by exposing a structured params object instead of relying on heuristics.
- Surface explicit pointers to input files so the frontend can know which sources were available at build time.

### Description
- Update `scripts/build_dashboard_assets.js` to include an `effective_params` object in the produced `dashboard_state.json` that combines `metrics_snapshot.params_used` (preferred) with `strategy_params` fallbacks and the computed `min_ev` fallback logic.
- Normalize special-character keys by mapping `"profit_€"` → `profit_eur` and `"roi_%"` → `roi_pct` in `effective_params` to avoid downstream UI issues.
- Add `params_sources` entries pointing to `metrics_snapshot.json` and optionally `strategy_params.json` / `strategy_params.txt` if present.
- No other dashboard behaviors (window computation, local_matched precedence, placeholder filtering, artifact copying) were modified.

### Testing
- Ran `node scripts/build_dashboard_assets.js` which completed successfully and prepared assets in `web/public/data`.
- Ran `cat web/public/data/dashboard_state.json | head -n 80` and confirmed `effective_params.home_win_rate_threshold`, `odds_min`, `odds_max`, `prob_threshold`, and `min_ev` are present along with `params_sources`.
- Automated checks passed (script run and JSON inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe81d9d3883318a83e89308157a76)