### PR TITLE
ci: use setup-chrome action in previous-game workflow

### DIFF
--- a/.github/workflows/1_get_data_previous_game_day_2026.yml
+++ b/.github/workflows/1_get_data_previous_game_day_2026.yml
@@ -30,9 +30,7 @@ jobs:
           cache: "pip"
 
       - name: Install Google Chrome
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
+        uses: browser-actions/setup-chrome@v1
 
       - name: Cache WebDriverManager
         uses: actions/cache@v3


### PR DESCRIPTION
### Motivation
- Replace fragile manual `apt-get install google-chrome-stable` with the maintained `browser-actions/setup-chrome@v1` to align Chrome setup across workflows and avoid apt-repo failures on GitHub runners.

### Description
- Updated `.github/workflows/1_get_data_previous_game_day_2026.yml` to remove the `sudo apt-get` installation block and use the `browser-actions/setup-chrome@v1` action instead.

### Testing
- Executed `rg -n "google-chrome-stable|setup-chrome" .github/workflows/*.yml` to confirm the replacement and consistency (success); inspected the updated workflow with `nl` and committed the change with `git commit` (success); attempted YAML parsing with a small Python script but that check failed because the environment lacks the `yaml` module, so full YAML validation could not be completed (warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993788908fc83318c8cdbc1f1597bc8)