### PR TITLE
Port live OOS proxy and market-aware safety guards into 2026 pipeline

### DIFF
--- a/2026/README.md
+++ b/2026/README.md
@@ -1,0 +1,33 @@
+# 2026 Live Probability Columns + Market Safety
+
+## Column precedence for live probabilities
+
+For upcoming rows, `prob_base` is selected as:
+
+1. `prob_live_oos_proxy` when `live_oos_proxy_ready=True`
+2. fallback: `home_team_prob`
+
+`prob_live_safe_pre_clip` is then clipped to `[0.35, 0.80]` before market-aware guards.
+
+## Market-aware guard thresholds
+
+- `UNDERDOG_ODDS_GUARD_MIN = 2.00`
+- `UNDERDOG_PROB_GUARD_MIN = 0.60`
+- `GAP_GUARD_MIN = 0.12`
+- `UNDERDOG_CAP = 0.55`
+- `TAU_GAP = 0.08`
+
+Policy is **A (strict)**: if hard guard triggers, `blocked_by="MODEL_MARKET_GAP"` and rows are excluded from live shortlist / bet-log additions.
+
+## Tuning
+
+### Live OOS proxy
+
+- `n_bins` controls quantile bin granularity (default 25).
+- `min_train_rows` controls readiness (default 300).
+- `min_bin_n` controls small-bin fallback to global rate (default 25).
+
+### Market blend
+
+- `TAU_GAP` controls how quickly model probability is blended toward market as model-market gap increases.
+  - smaller tau => stronger market pull for the same gap.

--- a/2026/scripts/maintain_bet_log_flat_live.py
+++ b/2026/scripts/maintain_bet_log_flat_live.py
@@ -17,8 +17,12 @@ ODDS_MIN = 2.10
 ODDS_MAX = 3.10
 HOME_WIN_RATE_MIN = 0.55
 PROB_MIN = 0.40
-UNDERDOG_ODDS_THRESHOLD = 2.30
-MODEL_MARKET_GAP_PROB_THRESHOLD = 0.60
+UNDERDOG_ODDS_GUARD_MIN = 2.00
+UNDERDOG_PROB_GUARD_MIN = 0.60
+GAP_GUARD_MIN = 0.12
+UNDERDOG_CAP = 0.55
+TAU_GAP = 0.08
+USE_BLEND_ALWAYS = True
 HARD_VETO_MODEL_MARKET_GAP = True
 
 
@@ -36,13 +40,17 @@ LEDGER_COLUMNS = [
     "prob_base",
     "prob_live_oos_proxy",
     "prob_live_safe_pre_clip",
-    "implied_prob_1",
+    "market_implied_p_raw",
+    "market_implied_p_devig",
     "model_market_gap",
     "model_market_gap_flag",
     "live_underdog_upscale_guard_triggered",
     "live_shrink_triggered",
     "live_oos_proxy_ready",
     "live_oos_proxy_train_rows",
+    "live_oos_proxy_bin_n",
+    "live_oos_proxy_bin_winrate",
+    "blocked_by",
     "ev_per_100",
     "created_at_utc",
     "settled_at_utc",
@@ -232,74 +240,69 @@ def _prepare_combined(df: pd.DataFrame) -> pd.DataFrame:
     combined["date"] = _normalize_date(combined[columns.date])
     combined["home_team"] = _normalize_team(combined[columns.home])
     combined["away_team"] = _normalize_team(combined[columns.away])
-    combined["odds_1"] = pd.to_numeric(combined[columns.odds], errors="coerce")
+    combined["odds_1"] = pd.to_numeric(combined.get("odds_1", combined[columns.odds]), errors="coerce")
+    combined["odds_2"] = pd.to_numeric(combined.get("odds_2", np.nan), errors="coerce")
 
-    combined["prob_selected"] = pd.to_numeric(combined[columns.prob], errors="coerce")
-    combined["prob_iso"] = pd.to_numeric(
-        combined.get("prob_iso_insample", combined.get("prob_iso", combined.get("iso_proba_home_win", np.nan))),
-        errors="coerce",
-    )
+    combined["home_team_prob"] = pd.to_numeric(combined.get("home_team_prob", combined[columns.prob]), errors="coerce")
+    combined["prob_iso"] = pd.to_numeric(combined.get("prob_iso", combined.get("prob_iso_insample", np.nan)), errors="coerce")
     combined["prob_iso_oos_time"] = pd.to_numeric(combined.get("prob_iso_oos_time", np.nan), errors="coerce")
     combined["prob_live_oos_proxy"] = pd.to_numeric(combined.get("prob_live_oos_proxy", np.nan), errors="coerce")
-    combined["prob_live_safe"] = pd.to_numeric(combined.get("prob_live_safe", combined["prob_selected"]), errors="coerce")
+
+    proxy_ready = combined.get("live_oos_proxy_ready", False)
+    proxy_ready = _to_bool_series(pd.Series(proxy_ready, index=combined.index)) if not isinstance(proxy_ready, pd.Series) else _to_bool_series(proxy_ready)
+    prob_live_base = combined["home_team_prob"].copy()
+    prob_live_base = np.where(proxy_ready.fillna(False), combined["prob_live_oos_proxy"].combine_first(combined["home_team_prob"]), combined["home_team_prob"])
+    combined["prob_base"] = pd.to_numeric(combined.get("prob_base", prob_live_base), errors="coerce")
+    combined["prob_live_safe_pre_clip"] = pd.to_numeric(combined.get("prob_live_safe_pre_clip", combined["prob_base"]), errors="coerce").clip(PROB_CLIP_LO, PROB_CLIP_HI)
+
+    combined["market_implied_p_raw"] = pd.to_numeric(
+        combined.get("market_implied_p_raw", np.where(combined["odds_1"] > 0, 1.0 / combined["odds_1"], np.nan)),
+        errors="coerce",
+    )
+    p2_raw = np.where(combined["odds_2"] > 0, 1.0 / combined["odds_2"], np.nan)
+    fallback_devig = combined["market_implied_p_raw"] / (combined["market_implied_p_raw"] + p2_raw)
+    combined["market_implied_p_devig"] = pd.to_numeric(combined.get("market_implied_p_devig", fallback_devig), errors="coerce")
+    p_market = combined["market_implied_p_devig"].where(combined["market_implied_p_devig"].notna(), combined["market_implied_p_raw"])
+
+    combined["model_market_gap"] = pd.to_numeric(combined.get("model_market_gap", combined["prob_live_safe_pre_clip"] - p_market), errors="coerce")
+
+    underdog_guard = (
+        (combined["odds_1"] >= UNDERDOG_ODDS_GUARD_MIN)
+        & (combined["prob_live_safe_pre_clip"] >= UNDERDOG_PROB_GUARD_MIN)
+        & (combined["model_market_gap"] >= GAP_GUARD_MIN)
+    ).fillna(False)
+    combined["live_underdog_upscale_guard_triggered"] = combined.get("live_underdog_upscale_guard_triggered", underdog_guard)
+
+    model_market_gap_flag = (combined["model_market_gap"] >= GAP_GUARD_MIN).fillna(False)
+    combined["model_market_gap_flag"] = _to_bool_series(combined.get("model_market_gap_flag", model_market_gap_flag)).fillna(model_market_gap_flag).astype(bool)
+
+    prob_guarded = np.where(underdog_guard, np.minimum(combined["prob_live_safe_pre_clip"], UNDERDOG_CAP), combined["prob_live_safe_pre_clip"])
+    blend_weight = np.exp(-np.abs(combined["model_market_gap"]) / TAU_GAP) if USE_BLEND_ALWAYS else np.ones(len(combined), dtype=float)
+    prob_blended = blend_weight * prob_guarded + (1.0 - blend_weight) * p_market
+
+    alpha = np.where(prob_blended > 0.60, 0.85, 1.0)
+    alpha = np.where(combined["model_market_gap_flag"], np.minimum(alpha, 0.70), alpha)
+    combined["live_shrink_triggered"] = combined.get("live_shrink_triggered", alpha < 1.0)
+
+    combined["prob_used"] = pd.to_numeric(combined.get("prob_used", 0.5 + alpha * (prob_blended - 0.5)), errors="coerce").clip(PROB_CLIP_LO, PROB_CLIP_HI)
 
     if columns.home_win_rate:
-        combined["home_win_rate"] = pd.to_numeric(
-            combined[columns.home_win_rate], errors="coerce"
-        )
+        combined["home_win_rate"] = pd.to_numeric(combined[columns.home_win_rate], errors="coerce")
     else:
         combined["home_win_rate"] = np.nan
 
-    combined["prob_live_safe_pre_clip"] = pd.to_numeric(
-        combined.get("prob_live_safe_pre_clip", combined["prob_live_safe"]),
-        errors="coerce",
-    )
-    combined["prob_base"] = pd.to_numeric(
-        combined.get("prob_base", combined["prob_live_safe_pre_clip"]),
-        errors="coerce",
-    )
-    combined["prob_used"] = pd.to_numeric(
-        combined.get("prob_used", combined["prob_base"]),
-        errors="coerce",
-    ).clip(PROB_CLIP_LO, PROB_CLIP_HI)
-
-    combined["implied_prob_1"] = pd.to_numeric(
-        combined.get("implied_prob_1", np.where(combined["odds_1"] > 0, 1.0 / combined["odds_1"], np.nan)),
-        errors="coerce",
-    )
-    combined["model_market_gap"] = pd.to_numeric(
-        combined.get("model_market_gap", combined["prob_base"] - combined["implied_prob_1"]),
-        errors="coerce",
-    )
-
-    gap_fallback = (
-        (combined["odds_1"] >= UNDERDOG_ODDS_THRESHOLD)
-        & (combined["prob_used"] >= MODEL_MARKET_GAP_PROB_THRESHOLD)
-    )
-    existing_gap_flag = combined.get("model_market_gap_flag")
-    if existing_gap_flag is None:
-        combined["model_market_gap_flag"] = gap_fallback.fillna(False).astype(bool)
-    else:
-        existing_gap_flag = _to_bool_series(existing_gap_flag)
-        combined["model_market_gap_flag"] = np.where(
-            existing_gap_flag.notna(),
-            existing_gap_flag.astype(bool),
-            gap_fallback.fillna(False).astype(bool),
-        )
-
-    combined["ev_per_100"] = (
-        combined["prob_used"] * (combined["odds_1"] - 1)
-        - (1 - combined["prob_used"])
-    ) * 100
+    combined["ev_per_100"] = (combined["prob_used"] * (combined["odds_1"] - 1) - (1 - combined["prob_used"])) * 100
 
     for debug_col in [
-        "prob_base", "prob_live_oos_proxy", "prob_live_safe_pre_clip", "implied_prob_1",
-        "model_market_gap", "model_market_gap_flag", "live_underdog_upscale_guard_triggered",
-        "live_shrink_triggered", "live_oos_proxy_ready", "live_oos_proxy_train_rows",
+        "prob_base", "prob_live_oos_proxy", "prob_live_safe_pre_clip", "market_implied_p_raw",
+        "market_implied_p_devig", "model_market_gap", "model_market_gap_flag",
+        "live_underdog_upscale_guard_triggered", "live_shrink_triggered", "live_oos_proxy_ready",
+        "live_oos_proxy_train_rows", "live_oos_proxy_bin_n", "live_oos_proxy_bin_winrate", "blocked_by",
     ]:
         if debug_col not in combined.columns:
             combined[debug_col] = np.nan
 
+    combined["blocked_by"] = combined.get("blocked_by", np.where(underdog_guard, "MODEL_MARKET_GAP", "PASS"))
     combined["win"] = _derive_home_won(combined)
 
     bad_prob = combined["prob_iso"] > 1
@@ -424,6 +427,9 @@ def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.DataFra
         & (upcoming["ev_per_100"] > MIN_EV)
     ].copy()
 
+    if "blocked_by" in qualifiers.columns:
+        qualifiers = qualifiers[qualifiers["blocked_by"].fillna("PASS").eq("PASS")].copy()
+
     if HARD_VETO_MODEL_MARKET_GAP and "model_market_gap_flag" in qualifiers.columns:
         gap_flag_raw = _to_bool_series(qualifiers["model_market_gap_flag"])
         gap_flag = np.where(gap_flag_raw.notna(), gap_flag_raw.astype(bool), False)
@@ -460,13 +466,17 @@ def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.DataFra
             "prob_base",
             "prob_live_oos_proxy",
             "prob_live_safe_pre_clip",
-            "implied_prob_1",
+            "market_implied_p_raw",
+            "market_implied_p_devig",
             "model_market_gap",
             "model_market_gap_flag",
             "live_underdog_upscale_guard_triggered",
             "live_shrink_triggered",
             "live_oos_proxy_ready",
             "live_oos_proxy_train_rows",
+            "live_oos_proxy_bin_n",
+            "live_oos_proxy_bin_winrate",
+            "blocked_by",
             "ev_per_100",
             "created_at_utc",
             "settled_at_utc",

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -27,7 +27,8 @@ import pandas as pd
 from sklearn.isotonic import IsotonicRegression
 from sklearn.metrics import brier_score_loss, log_loss
 
-from live_calibration import compute_live_oos_proxy, compute_time_oos_isotonic
+from live_calibration import compute_time_oos_isotonic
+from live_oos_proxy import apply_live_oos_proxy, build_live_oos_proxy
 from live_safety import apply_live_safety
 
 from nba_utils_2026 import (
@@ -55,7 +56,7 @@ PROB_COL_HIST = PROB_ISO_OOS_TIME_COL
 PROB_COL_LIVE = PROB_LIVE_SAFE_COL
 MIN_TRAIN_OOS_TIME = 50
 MIN_STEP_OOS_TIME = 10
-MIN_TRAIN_OOS_PROXY = 200
+MIN_TRAIN_OOS_PROXY = 300
 
 # Grid search
 FLAT_STAKE = 100.0
@@ -527,33 +528,51 @@ def build_live_probability_columns(df_all: pd.DataFrame, today_date, tomorrow_da
         min_step=MIN_STEP_OOS_TIME,
     )
 
-    proxy_result = compute_live_oos_proxy(
-        df,
-        played_mask=played_mask,
-        upcoming_mask=upcoming_mask,
-        prob_col=PRED_PROBA_COL,
-        target_col=RESULT_COL,
-        oos_col=PROB_ISO_OOS_TIME_COL,
-        min_train_oos=MIN_TRAIN_OOS_PROXY,
+    played_df = df.loc[played_mask].copy()
+    played_df["home_team_prob"] = pd.to_numeric(played_df[PRED_PROBA_COL], errors="coerce")
+    played_df["win"] = pd.to_numeric(played_df[RESULT_COL], errors="coerce")
+
+    proxy_obj = build_live_oos_proxy(
+        played_df,
+        prob_source_cols=[PROB_ISO_OOS_TIME_COL, "home_team_prob"],
+        target_col="win",
+        n_bins=25,
+        min_train_rows=MIN_TRAIN_OOS_PROXY,
+        min_bin_n=25,
+        use_wilson_lb=True,
     )
-    df[PROB_LIVE_OOS_PROXY_COL] = proxy_result.proxy
-    df["live_oos_proxy_ready"] = bool(proxy_result.ready)
-    df["live_oos_proxy_train_rows"] = int(proxy_result.train_rows)
+
+    df["live_oos_proxy_ready"] = bool(proxy_obj["ready"])
+    df["live_oos_proxy_train_rows"] = int(proxy_obj["train_rows"])
+    df["live_oos_proxy_bin_n"] = 0
+    df["live_oos_proxy_bin_winrate"] = np.nan
+
+    upcoming_df = df.loc[upcoming_mask].copy()
+    upcoming_df["home_team_prob"] = pd.to_numeric(upcoming_df[PRED_PROBA_COL], errors="coerce")
+    upcoming_with_proxy = apply_live_oos_proxy(upcoming_df, proxy_obj, in_col="home_team_prob")
+    for c in [
+        "prob_live_oos_proxy",
+        "live_oos_proxy_ready",
+        "live_oos_proxy_train_rows",
+        "live_oos_proxy_bin_n",
+        "live_oos_proxy_bin_winrate",
+    ]:
+        df.loc[upcoming_with_proxy.index, c] = upcoming_with_proxy[c]
 
     logging.info(
         "[LIVE OOS PROXY] ready=%s train_rows=%d win_rate=%.4f",
-        proxy_result.ready,
-        proxy_result.train_rows,
-        proxy_result.win_rate if np.isfinite(proxy_result.win_rate) else float("nan"),
+        proxy_obj["ready"],
+        proxy_obj["train_rows"],
+        proxy_obj["global_win_rate"] if np.isfinite(proxy_obj["global_win_rate"]) else float("nan"),
     )
 
-    safety_ready = bool(proxy_result.ready)
+    safety_ready = bool(proxy_obj["ready"])
     df = apply_live_safety(df, live_oos_proxy_ready=safety_ready)
     df[PROB_LIVE_SAFE_COL] = df["prob_base"]
 
     meta = {
-        "live_oos_proxy_ready": bool(proxy_result.ready),
-        "live_oos_proxy_train_rows": int(proxy_result.train_rows),
+        "live_oos_proxy_ready": bool(proxy_obj["ready"]),
+        "live_oos_proxy_train_rows": int(proxy_obj["train_rows"]),
     }
     return df, meta
 
@@ -561,9 +580,10 @@ def build_live_probability_columns(df_all: pd.DataFrame, today_date, tomorrow_da
 def run_self_test(df_all: pd.DataFrame, live_meta: dict | None = None) -> None:
     required_cols = [
         "home_team_prob", "prob_iso", PROB_ISO_OOS_TIME_COL, PROB_LIVE_OOS_PROXY_COL,
-        "prob_live_safe_pre_clip", "prob_base", "prob_used", "implied_prob_1",
-        "model_market_gap", "model_market_gap_flag", "live_underdog_upscale_guard_triggered",
-        "live_shrink_triggered", "live_oos_proxy_ready", "live_oos_proxy_train_rows",
+        "prob_live_safe_pre_clip", "prob_base", "prob_used", "market_implied_p_raw",
+        "market_implied_p_devig", "model_market_gap", "model_market_gap_flag",
+        "live_underdog_upscale_guard_triggered", "live_shrink_triggered", "live_oos_proxy_ready",
+        "live_oos_proxy_train_rows", "live_oos_proxy_bin_n", "live_oos_proxy_bin_winrate", "blocked_by",
     ]
     missing = [c for c in required_cols if c not in df_all.columns]
     if missing:
@@ -583,13 +603,13 @@ def run_self_test(df_all: pd.DataFrame, live_meta: dict | None = None) -> None:
         if train_rows >= MIN_TRAIN_OOS_PROXY and not ready:
             raise AssertionError("Expected live_oos_proxy_ready=True when train_rows is sufficient")
 
-    suspicious = df_all[(pd.to_numeric(df_all.get("odds_1"), errors="coerce") >= 2.30) & (pd.to_numeric(df_all.get("prob_live_base"), errors="coerce") >= 0.60)]
+    suspicious = df_all[(pd.to_numeric(df_all.get("odds_1"), errors="coerce") >= 2.30) & (pd.to_numeric(df_all.get("prob_live_safe_pre_clip"), errors="coerce") >= 0.60)]
     if not suspicious.empty:
         if not suspicious["model_market_gap_flag"].fillna(False).any():
             raise AssertionError("Expected underdog/high-prob rows to trigger model_market_gap_flag")
-        reduced = suspicious["prob_used"] < suspicious["prob_live_base"]
+        reduced = suspicious["prob_used"] <= 0.55
         if not reduced.any():
-            raise AssertionError("Expected underdog/high-prob rows to reduce prob_used")
+            raise AssertionError("Expected underdog/high-prob rows to cap/shrink prob_used")
 
 def evaluate_params_on_hist_window(
     hist_window: pd.DataFrame,
@@ -909,12 +929,15 @@ def build_bet_shortlist(df_all: pd.DataFrame, params: dict, min_ev: float) -> pd
         (out["EV_€_per_100"] > float(min_ev))
     )
     shortlist = out.loc[mask].copy()
+    if "blocked_by" in shortlist.columns:
+        shortlist = shortlist[shortlist["blocked_by"].fillna("PASS").eq("PASS")].copy()
     cols = [
         DATE_COL, "home_team", "away_team", "home_team_prob", "prob_iso", PROB_ISO_OOS_TIME_COL,
         PROB_LIVE_OOS_PROXY_COL, "prob_live_safe_pre_clip", "prob_base", "prob_used",
-        "odds_1", "implied_prob_1", "model_market_gap", "model_market_gap_flag",
+        "odds_1", "market_implied_p_raw", "market_implied_p_devig", "model_market_gap", "model_market_gap_flag",
         "live_underdog_upscale_guard_triggered", "live_shrink_triggered",
-        "live_oos_proxy_ready", "live_oos_proxy_train_rows", HOMEWR_COL, "EV_€_per_100",
+        "live_oos_proxy_ready", "live_oos_proxy_train_rows", "live_oos_proxy_bin_n",
+        "live_oos_proxy_bin_winrate", "blocked_by", HOMEWR_COL, "EV_€_per_100",
     ]
     for c in cols:
         if c not in shortlist.columns:

--- a/2026/src/live_oos_proxy.py
+++ b/2026/src/live_oos_proxy.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+DEFAULT_PROB_SOURCE_COLS = ["prob_iso_oos_time", "home_team_prob"]
+
+
+def _wilson_lower_bound(wins: float, n: float, z: float = 1.96) -> float:
+    if n <= 0:
+        return float("nan")
+    p_hat = wins / n
+    denom = 1.0 + (z**2) / n
+    center = p_hat + (z**2) / (2.0 * n)
+    margin = z * np.sqrt((p_hat * (1.0 - p_hat) / n) + (z**2) / (4.0 * (n**2)))
+    return float((center - margin) / denom)
+
+
+def _select_source_col(
+    df_played: pd.DataFrame,
+    prob_source_cols: list[str],
+    target_col: str,
+    min_train_rows: int,
+) -> tuple[str, pd.Series]:
+    for col in prob_source_cols:
+        if col not in df_played.columns:
+            continue
+        mask = df_played[col].notna() & df_played[target_col].notna()
+        if int(mask.sum()) < min_train_rows:
+            continue
+        if df_played.loc[mask, target_col].nunique() < 2:
+            continue
+        return col, mask
+
+    fallback = "home_team_prob" if "home_team_prob" in df_played.columns else prob_source_cols[0]
+    mask = df_played.get(fallback, pd.Series(index=df_played.index, dtype=float)).notna() & df_played[target_col].notna()
+    return fallback, mask
+
+
+def _make_edges(series: pd.Series, n_bins: int) -> np.ndarray:
+    values = pd.to_numeric(series, errors="coerce").dropna().to_numpy(dtype=float)
+    if values.size == 0:
+        return np.array([0.0, 1.0], dtype=float)
+
+    q_edges = np.unique(np.quantile(values, q=np.linspace(0, 1, n_bins + 1)))
+    if q_edges.size >= 3:
+        q_edges[0] = min(q_edges[0], 0.0)
+        q_edges[-1] = max(q_edges[-1], 1.0)
+        return q_edges
+
+    return np.linspace(0.0, 1.0, n_bins + 1, dtype=float)
+
+
+def build_live_oos_proxy(
+    df_played: pd.DataFrame,
+    prob_source_cols: list[str] = DEFAULT_PROB_SOURCE_COLS,
+    target_col: str = "win",
+    n_bins: int = 25,
+    min_train_rows: int = 300,
+    min_bin_n: int = 25,
+    use_wilson_lb: bool = True,
+    smoothing_alpha: float = 1.0,
+) -> dict[str, Any]:
+    if target_col not in df_played.columns:
+        raise KeyError(f"Missing target_col={target_col}")
+
+    source_col, train_mask = _select_source_col(df_played, prob_source_cols, target_col, min_train_rows)
+
+    work = df_played.loc[train_mask, [source_col, target_col]].copy()
+    work[source_col] = pd.to_numeric(work[source_col], errors="coerce")
+    work[target_col] = pd.to_numeric(work[target_col], errors="coerce")
+    work = work.dropna(subset=[source_col, target_col])
+
+    train_rows = int(len(work))
+    global_wr = float(work[target_col].mean()) if train_rows else float("nan")
+    ready = bool(train_rows >= min_train_rows and work[target_col].nunique() >= 2)
+
+    edges = _make_edges(work[source_col], n_bins)
+    bin_n = np.zeros(len(edges) - 1, dtype=int)
+    bin_wr = np.full(len(edges) - 1, np.nan, dtype=float)
+
+    if ready:
+        clipped = np.clip(work[source_col].to_numpy(dtype=float), edges[0], edges[-1])
+        bin_idx = np.clip(np.digitize(clipped, bins=edges[1:-1], right=False), 0, len(edges) - 2)
+        y = work[target_col].to_numpy(dtype=float)
+
+        for i in range(len(edges) - 1):
+            m = bin_idx == i
+            n_i = int(m.sum())
+            bin_n[i] = n_i
+            if n_i == 0:
+                continue
+            wins = float(y[m].sum())
+            if use_wilson_lb:
+                score = _wilson_lower_bound(wins, n_i)
+            else:
+                score = (wins + smoothing_alpha) / (n_i + 2.0 * smoothing_alpha)
+            bin_wr[i] = float(score)
+
+        low_n = bin_n < int(min_bin_n)
+        if np.any(low_n):
+            bin_wr[low_n] = global_wr
+
+        bin_wr = np.where(np.isnan(bin_wr), global_wr, bin_wr)
+
+    def predict_proxy(p: float) -> tuple[float, int, float]:
+        if not ready or p is None or np.isnan(p):
+            return float("nan"), 0, float("nan")
+        p_clipped = float(np.clip(p, edges[0], edges[-1]))
+        idx = int(np.clip(np.digitize([p_clipped], bins=edges[1:-1], right=False)[0], 0, len(edges) - 2))
+        return float(bin_wr[idx]), int(bin_n[idx]), float(bin_wr[idx])
+
+    return {
+        "ready": ready,
+        "train_rows": train_rows,
+        "global_win_rate": global_wr,
+        "bin_edges": edges,
+        "bin_n": bin_n,
+        "bin_win_rate": bin_wr,
+        "source_col_used": source_col,
+        "predict_proxy": predict_proxy,
+    }
+
+
+def apply_live_oos_proxy(
+    df_upcoming: pd.DataFrame,
+    proxy_obj: dict[str, Any],
+    in_col: str = "home_team_prob",
+) -> pd.DataFrame:
+    out = df_upcoming.copy()
+    ready = bool(proxy_obj.get("ready", False))
+    train_rows = int(proxy_obj.get("train_rows", 0))
+
+    out["prob_live_oos_proxy"] = np.nan
+    out["live_oos_proxy_ready"] = ready
+    out["live_oos_proxy_train_rows"] = train_rows
+    out["live_oos_proxy_bin_n"] = 0
+    out["live_oos_proxy_bin_winrate"] = np.nan
+
+    if not ready or "predict_proxy" not in proxy_obj:
+        return out
+
+    p_in = pd.to_numeric(out.get(in_col), errors="coerce")
+    preds = p_in.apply(proxy_obj["predict_proxy"])
+    out["prob_live_oos_proxy"] = preds.apply(lambda x: x[0] if isinstance(x, tuple) else np.nan)
+    out["live_oos_proxy_bin_n"] = preds.apply(lambda x: x[1] if isinstance(x, tuple) else 0).astype(int)
+    out["live_oos_proxy_bin_winrate"] = preds.apply(lambda x: x[2] if isinstance(x, tuple) else np.nan)
+    return out

--- a/2026/src/live_safety.py
+++ b/2026/src/live_safety.py
@@ -3,50 +3,67 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from odds_utils import compute_market_probs
 
-UNDERDOG_ODDS = 2.30
-HIGH_PROB_FOR_UNDERDOG = 0.60
-GAP_ABS_THRESHOLD = 0.20
-GAP_CAP = 0.15
-BASE_SHRINK = 0.85
-STRONGER_SHRINK = 0.75
 P_MIN = 0.35
 P_MAX = 0.80
+UNDERDOG_ODDS_GUARD_MIN = 2.00
+UNDERDOG_PROB_GUARD_MIN = 0.60
+GAP_GUARD_MIN = 0.12
+UNDERDOG_CAP = 0.55
+TAU_GAP = 0.08
+USE_BLEND_ALWAYS = True
 
 
 def apply_live_safety(df: pd.DataFrame, *, live_oos_proxy_ready: bool) -> pd.DataFrame:
     out = df.copy()
 
-    odds = pd.to_numeric(out.get("odds_1"), errors="coerce")
-    implied = np.where(odds > 0, 1.0 / odds, np.nan)
-    out["implied_prob_1"] = implied
+    out["home_team_prob"] = pd.to_numeric(out.get("home_team_prob"), errors="coerce")
+    out["prob_iso"] = pd.to_numeric(out.get("prob_iso", out.get("iso_proba_home_win")), errors="coerce")
+    out["prob_iso_oos_time"] = pd.to_numeric(out.get("prob_iso_oos_time"), errors="coerce")
+    out["prob_live_oos_proxy"] = pd.to_numeric(out.get("prob_live_oos_proxy"), errors="coerce")
+    odds_1 = pd.to_numeric(out.get("odds_1"), errors="coerce")
+    odds_2 = pd.to_numeric(out.get("odds_2"), errors="coerce")
 
-    base = pd.to_numeric(out.get("home_team_prob"), errors="coerce")
-    if "prob_live_oos_proxy" in out.columns and live_oos_proxy_ready:
-        base = pd.to_numeric(out["prob_live_oos_proxy"], errors="coerce").combine_first(base)
-    if "prob_iso_oos_time" in out.columns:
-        base = pd.to_numeric(out["prob_iso_oos_time"], errors="coerce").combine_first(base)
+    p_raw, p_devig = compute_market_probs(odds_1, odds_2)
+    out["market_implied_p_raw"] = p_raw
+    out["market_implied_p_devig"] = p_devig
 
-    out["prob_live_base"] = base
+    p_market = pd.Series(p_devig, index=out.index, dtype=float)
+    p_market = p_market.where(p_market.notna(), pd.Series(p_raw, index=out.index, dtype=float))
 
-    gap = base - out["implied_prob_1"]
-    out["model_market_gap"] = gap
+    base = out["home_team_prob"].copy()
+    if live_oos_proxy_ready:
+        base = out["prob_live_oos_proxy"].combine_first(base)
 
-    underdog_trigger = (odds >= UNDERDOG_ODDS) & (base >= HIGH_PROB_FOR_UNDERDOG)
-    gap_trigger = gap.abs() >= GAP_ABS_THRESHOLD
-    flag = (underdog_trigger | gap_trigger).fillna(False)
-    out["model_market_gap_flag"] = flag
-    out["live_underdog_upscale_guard_triggered"] = underdog_trigger.fillna(False)
+    out["prob_base"] = base
+    out["prob_live_safe_pre_clip"] = pd.to_numeric(base, errors="coerce").clip(P_MIN, P_MAX)
 
-    cap_target = out["implied_prob_1"] + GAP_CAP
-    guarded_base = np.where(flag, np.minimum(base, cap_target), base)
-    out["prob_live_base"] = guarded_base
+    out["model_market_gap"] = out["prob_live_safe_pre_clip"] - p_market
+    underdog_guard = (
+        (odds_1 >= UNDERDOG_ODDS_GUARD_MIN)
+        & (out["prob_live_safe_pre_clip"] >= UNDERDOG_PROB_GUARD_MIN)
+        & (out["model_market_gap"] >= GAP_GUARD_MIN)
+    ).fillna(False)
 
-    shrink = np.where(flag, STRONGER_SHRINK, BASE_SHRINK)
-    out["live_shrink_triggered"] = flag
+    out["model_market_gap_flag"] = (out["model_market_gap"] >= GAP_GUARD_MIN).fillna(False)
+    out["live_underdog_upscale_guard_triggered"] = underdog_guard
 
-    out["prob_live_safe_pre_clip"] = 0.5 + shrink * (pd.to_numeric(out["prob_live_base"], errors="coerce") - 0.5)
-    out["prob_base"] = out["prob_live_safe_pre_clip"]
-    out["prob_used"] = out["prob_base"].clip(lower=P_MIN, upper=P_MAX)
+    prob_guarded = out["prob_live_safe_pre_clip"].where(~underdog_guard, np.minimum(out["prob_live_safe_pre_clip"], UNDERDOG_CAP))
+
+    if USE_BLEND_ALWAYS:
+        blend_weight = np.exp(-np.abs(out["model_market_gap"]) / TAU_GAP)
+    else:
+        blend_weight = np.ones(len(out), dtype=float)
+    out["prob_blended"] = blend_weight * prob_guarded + (1.0 - blend_weight) * p_market
+
+    alpha = np.where(out["prob_blended"] > 0.60, 0.85, 1.0)
+    alpha = np.where(out["model_market_gap_flag"].astype(bool), np.minimum(alpha, 0.70), alpha)
+
+    out["live_shrink_triggered"] = (alpha < 1.0)
+    out["prob_used"] = (0.5 + alpha * (out["prob_blended"] - 0.5)).clip(P_MIN, P_MAX)
+
+    out["blocked_by"] = np.where(underdog_guard, "MODEL_MARKET_GAP", "PASS")
+    out["implied_prob_1"] = out["market_implied_p_raw"]
 
     return out

--- a/2026/src/odds_utils.py
+++ b/2026/src/odds_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def implied_prob_decimal(odds):
+    odds_num = pd.to_numeric(odds, errors="coerce")
+    return np.where(odds_num > 0, 1.0 / odds_num, np.nan)
+
+
+def devig_two_way(p1_raw, p2_raw):
+    p1 = pd.to_numeric(p1_raw, errors="coerce")
+    p2 = pd.to_numeric(p2_raw, errors="coerce")
+    denom = p1 + p2
+    return np.where(denom > 0, p1 / denom, np.nan)
+
+
+def compute_market_probs(odds_1, odds_2=None):
+    p_raw = implied_prob_decimal(odds_1)
+    if odds_2 is None:
+        return p_raw, np.full_like(np.asarray(p_raw, dtype=float), np.nan, dtype=float)
+    p2_raw = implied_prob_decimal(odds_2)
+    p_devig = devig_two_way(p_raw, p2_raw)
+    return p_raw, p_devig

--- a/2026/tests/test_live_safety.py
+++ b/2026/tests/test_live_safety.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from live_oos_proxy import apply_live_oos_proxy, build_live_oos_proxy
+from live_safety import UNDERDOG_CAP, apply_live_safety
+
+
+def test_underdog_gap_guard_caps_or_blocks():
+    df = pd.DataFrame(
+        {
+            "home_team_prob": [0.684],
+            "prob_live_oos_proxy": [0.684],
+            "odds_1": [2.30],
+            "odds_2": [1.65],
+        }
+    )
+
+    out = apply_live_safety(df, live_oos_proxy_ready=True)
+    row = out.iloc[0]
+
+    assert bool(row["model_market_gap_flag"]) is True
+    assert bool(row["live_underdog_upscale_guard_triggered"]) is True
+    assert row["blocked_by"] == "MODEL_MARKET_GAP"
+    assert float(row["prob_used"]) <= UNDERDOG_CAP
+
+
+def test_live_oos_proxy_ready_and_fills_upcoming():
+    rng = np.random.default_rng(42)
+    n = 420
+    p = rng.uniform(0.35, 0.75, size=n)
+    y = rng.binomial(1, p)
+    played = pd.DataFrame(
+        {
+            "home_team_prob": p,
+            "prob_iso_oos_time": np.clip(p + rng.normal(0, 0.03, size=n), 0.01, 0.99),
+            "win": y,
+        }
+    )
+
+    proxy = build_live_oos_proxy(played, min_train_rows=300)
+    assert proxy["ready"] is True
+
+    upcoming = pd.DataFrame({"home_team_prob": [0.41, 0.52, 0.68]})
+    out = apply_live_oos_proxy(upcoming, proxy)
+
+    assert out["live_oos_proxy_ready"].all()
+    assert out["prob_live_oos_proxy"].notna().all()


### PR DESCRIPTION
### Motivation
- Prevent upcoming predictions from relying primarily on raw `home_team_prob` by providing a live out-of-sample calibration proxy derived from historically played rows.
- Add market-aware guards and continuous shrink/blend so clear market disagreement (e.g. underdog odds ≈ 2.3 vs model prob ≈ 0.68) cannot pass with an inflated `prob_used`.
- Persist debug/forensic columns in CSVs so full traceability is available for downstream review and tuning.

### Description
- Added `2026/src/live_oos_proxy.py` which builds a live OOS proxy from played rows with source-col selection (`prob_iso_oos_time` → fallback `home_team_prob`), quantile bins with fixed-width fallback, per-bin counts/winrates, Wilson-LB (or Laplace) smoothing, and a `predict_proxy` helper plus `apply_live_oos_proxy` for upcoming rows.
- Added `2026/src/odds_utils.py` with `implied_prob_decimal`, `devig_two_way`, and `compute_market_probs` helpers and integrated these into safety logic.
- Reworked live safety in `2026/src/live_safety.py` to compute market implied raw/devig, model-market gap, hard underdog guard and cap (`UNDERDOG_CAP=0.55`), continuous market blend (`TAU_GAP=0.08`), continuous shrink rules (alpha behavior starting at 0.60), set `blocked_by` to `MODEL_MARKET_GAP` under Policy A (strict), and expose all debug columns (`market_implied_p_raw`, `market_implied_p_devig`, `model_market_gap`, flags, `prob_blended`, etc.).
- Updated `2026/src/5_Isotonic_based_betting_strategy_2026.py` to integrate the new proxy (`MIN_TRAIN_OOS_PROXY=300`), apply `apply_live_oos_proxy` to upcoming rows, persist proxy diagnostics (`live_oos_proxy_train_rows`, `live_oos_proxy_bin_n`, `live_oos_proxy_bin_winrate`), and enforce strict blocking when building the shortlist.
- Updated `2026/scripts/maintain_bet_log_flat_live.py` to coerce odds, compute/fallback market probabilities, apply the same guard/blend/shrink logic, persist the new forensic columns to ledger exports, and filter blocked rows out of automatic bet appends.
- Added `2026/tests/test_live_safety.py` with two unit tests covering the underdog gap guard behavior and proxy readiness/application, and added `2026/README.md` documenting precedence, thresholds and tuning knobs.

### Testing
- Ran byte-compile check with `python -m py_compile` on modified modules and it completed without errors.
- Ran unit tests with `pytest -q 2026/tests/test_live_safety.py` and the suite passed `2 passed`.
- Sanity-checked application-level behavior by ensuring `apply_live_oos_proxy` fills upcoming rows when proxy is ready and that `apply_live_safety` triggers the underdog guard and sets `blocked_by="MODEL_MARKET_GAP"` for the LAL–DEN-like scenario.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5bd436c3c833192264cecedadacec)