### PR TITLE
Unify live probability pipeline and align ledger with dynamic strategy params

### DIFF
--- a/2026/scripts/maintain_bet_log_flat_live.py
+++ b/2026/scripts/maintain_bet_log_flat_live.py
@@ -8,6 +8,14 @@ from typing import Iterable
 import numpy as np
 import pandas as pd
 
+import sys
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from live_probability_pipeline import load_active_strategy_params, prepare_live_probability_columns
+
 
 PROB_CLIP_LO = 0.35
 PROB_CLIP_HI = 0.80
@@ -240,51 +248,29 @@ def _prepare_combined(df: pd.DataFrame) -> pd.DataFrame:
     combined["date"] = _normalize_date(combined[columns.date])
     combined["home_team"] = _normalize_team(combined[columns.home])
     combined["away_team"] = _normalize_team(combined[columns.away])
+    combined["game_date"] = pd.to_datetime(combined[columns.date], errors="coerce", format="mixed")
+
     combined["odds_1"] = pd.to_numeric(combined.get("odds_1", combined[columns.odds]), errors="coerce")
     combined["odds_2"] = pd.to_numeric(combined.get("odds_2", np.nan), errors="coerce")
-
-    combined["home_team_prob"] = pd.to_numeric(combined.get("home_team_prob", combined[columns.prob]), errors="coerce")
+    combined["pred_home_win_proba"] = pd.to_numeric(combined.get("pred_home_win_proba", combined[columns.prob]), errors="coerce")
+    combined["home_team_prob"] = pd.to_numeric(combined.get("home_team_prob", combined["pred_home_win_proba"]), errors="coerce")
     combined["prob_iso"] = pd.to_numeric(combined.get("prob_iso", combined.get("prob_iso_insample", np.nan)), errors="coerce")
-    combined["prob_iso_oos_time"] = pd.to_numeric(combined.get("prob_iso_oos_time", np.nan), errors="coerce")
-    combined["prob_live_oos_proxy"] = pd.to_numeric(combined.get("prob_live_oos_proxy", np.nan), errors="coerce")
+    combined["home_team_won"] = _derive_home_won(combined)
+    combined["result_raw"] = np.where(combined["home_team_won"].notna(), combined["home_team_won"], 0)
 
-    proxy_ready = combined.get("live_oos_proxy_ready", False)
-    proxy_ready = _to_bool_series(pd.Series(proxy_ready, index=combined.index)) if not isinstance(proxy_ready, pd.Series) else _to_bool_series(proxy_ready)
-    prob_live_base = combined["home_team_prob"].copy()
-    prob_live_base = np.where(proxy_ready.fillna(False), combined["prob_live_oos_proxy"].combine_first(combined["home_team_prob"]), combined["home_team_prob"])
-    combined["prob_base"] = pd.to_numeric(combined.get("prob_base", prob_live_base), errors="coerce")
-    combined["prob_live_safe_pre_clip"] = pd.to_numeric(combined.get("prob_live_safe_pre_clip", combined["prob_base"]), errors="coerce").clip(PROB_CLIP_LO, PROB_CLIP_HI)
-
-    combined["market_implied_p_raw"] = pd.to_numeric(
-        combined.get("market_implied_p_raw", np.where(combined["odds_1"] > 0, 1.0 / combined["odds_1"], np.nan)),
-        errors="coerce",
+    combined = prepare_live_probability_columns(
+        combined,
+        clip_lo=PROB_CLIP_LO,
+        clip_hi=PROB_CLIP_HI,
+        config={
+            "date_col": "game_date",
+            "result_col": "home_team_won",
+            "result_raw_col": "result_raw",
+            "pred_proba_col": "pred_home_win_proba",
+            "prob_iso_oos_time_col": "prob_iso_oos_time",
+            "compute_oos_chain": False,
+        },
     )
-    p2_raw = np.where(combined["odds_2"] > 0, 1.0 / combined["odds_2"], np.nan)
-    fallback_devig = combined["market_implied_p_raw"] / (combined["market_implied_p_raw"] + p2_raw)
-    combined["market_implied_p_devig"] = pd.to_numeric(combined.get("market_implied_p_devig", fallback_devig), errors="coerce")
-    p_market = combined["market_implied_p_devig"].where(combined["market_implied_p_devig"].notna(), combined["market_implied_p_raw"])
-
-    combined["model_market_gap"] = pd.to_numeric(combined.get("model_market_gap", combined["prob_live_safe_pre_clip"] - p_market), errors="coerce")
-
-    underdog_guard = (
-        (combined["odds_1"] >= UNDERDOG_ODDS_GUARD_MIN)
-        & (combined["prob_live_safe_pre_clip"] >= UNDERDOG_PROB_GUARD_MIN)
-        & (combined["model_market_gap"] >= GAP_GUARD_MIN)
-    ).fillna(False)
-    combined["live_underdog_upscale_guard_triggered"] = combined.get("live_underdog_upscale_guard_triggered", underdog_guard)
-
-    model_market_gap_flag = (combined["model_market_gap"] >= GAP_GUARD_MIN).fillna(False)
-    combined["model_market_gap_flag"] = _to_bool_series(combined.get("model_market_gap_flag", model_market_gap_flag)).fillna(model_market_gap_flag).astype(bool)
-
-    prob_guarded = np.where(underdog_guard, np.minimum(combined["prob_live_safe_pre_clip"], UNDERDOG_CAP), combined["prob_live_safe_pre_clip"])
-    blend_weight = np.exp(-np.abs(combined["model_market_gap"]) / TAU_GAP) if USE_BLEND_ALWAYS else np.ones(len(combined), dtype=float)
-    prob_blended = blend_weight * prob_guarded + (1.0 - blend_weight) * p_market
-
-    alpha = np.where(prob_blended > 0.60, 0.85, 1.0)
-    alpha = np.where(combined["model_market_gap_flag"], np.minimum(alpha, 0.70), alpha)
-    combined["live_shrink_triggered"] = combined.get("live_shrink_triggered", alpha < 1.0)
-
-    combined["prob_used"] = pd.to_numeric(combined.get("prob_used", 0.5 + alpha * (prob_blended - 0.5)), errors="coerce").clip(PROB_CLIP_LO, PROB_CLIP_HI)
 
     if columns.home_win_rate:
         combined["home_win_rate"] = pd.to_numeric(combined[columns.home_win_rate], errors="coerce")
@@ -293,16 +279,6 @@ def _prepare_combined(df: pd.DataFrame) -> pd.DataFrame:
 
     combined["ev_per_100"] = (combined["prob_used"] * (combined["odds_1"] - 1) - (1 - combined["prob_used"])) * 100
 
-    for debug_col in [
-        "prob_base", "prob_live_oos_proxy", "prob_live_safe_pre_clip", "market_implied_p_raw",
-        "market_implied_p_devig", "model_market_gap", "model_market_gap_flag",
-        "live_underdog_upscale_guard_triggered", "live_shrink_triggered", "live_oos_proxy_ready",
-        "live_oos_proxy_train_rows", "live_oos_proxy_bin_n", "live_oos_proxy_bin_winrate", "blocked_by",
-    ]:
-        if debug_col not in combined.columns:
-            combined[debug_col] = np.nan
-
-    combined["blocked_by"] = combined.get("blocked_by", np.where(underdog_guard, "MODEL_MARKET_GAP", "PASS"))
     combined["win"] = _derive_home_won(combined)
 
     bad_prob = combined["prob_iso"] > 1
@@ -415,16 +391,23 @@ def _dedupe_ledger(ledger: pd.DataFrame) -> pd.DataFrame:
     return ledger.drop_duplicates(subset=["game_key"], keep="first")
 
 
-def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame) -> pd.DataFrame:
+def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame, params: dict[str, float] | None = None) -> pd.DataFrame:
     existing_keys = set(ledger["game_key"].dropna())
 
     upcoming = combined[combined["win"].isna()].copy()
+    active = params or {}
+    home_win_rate_min = float(active.get("home_win_rate_threshold", HOME_WIN_RATE_MIN))
+    odds_min = float(active.get("odds_min", ODDS_MIN))
+    odds_max = float(active.get("odds_max", ODDS_MAX))
+    prob_min = float(active.get("prob_threshold", PROB_MIN))
+    min_ev = float(active.get("min_ev", MIN_EV))
+
     qualifiers = upcoming[
-        (upcoming["home_win_rate"] >= HOME_WIN_RATE_MIN)
-        & (upcoming["odds_1"] >= ODDS_MIN)
-        & (upcoming["odds_1"] <= ODDS_MAX)
-        & (upcoming["prob_used"] >= PROB_MIN)
-        & (upcoming["ev_per_100"] > MIN_EV)
+        (upcoming["home_win_rate"] >= home_win_rate_min)
+        & (upcoming["odds_1"] >= odds_min)
+        & (upcoming["odds_1"] <= odds_max)
+        & (upcoming["prob_used"] >= prob_min)
+        & (upcoming["ev_per_100"] > min_ev)
     ].copy()
 
     if "blocked_by" in qualifiers.columns:
@@ -529,7 +512,8 @@ def main() -> None:
 
     ledger = _load_ledger(ledger_path)
     ledger = _settle_pending_bets(ledger, combined)
-    ledger = _append_new_bets(ledger, combined)
+    active_params = load_active_strategy_params(repo_root)
+    ledger = _append_new_bets(ledger, combined, params=active_params)
     ledger = _dedupe_ledger(ledger)
 
     ledger = ledger.sort_values(["date", "home_team", "away_team"], na_position="last")

--- a/2026/scripts/verify_pipeline_consistency.py
+++ b/2026/scripts/verify_pipeline_consistency.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import sys
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from live_probability_pipeline import load_active_strategy_params, prepare_live_probability_columns
+
+
+KEY_COLS = ["prob_used", "model_market_gap", "model_market_gap_flag", "blocked_by"]
+DEBUG_COLS = [
+    "prob_base",
+    "prob_live_safe_pre_clip",
+    "prob_live_oos_proxy",
+    "market_implied_p_raw",
+    "market_implied_p_devig",
+    "model_market_gap",
+    "model_market_gap_flag",
+    "live_underdog_upscale_guard_triggered",
+    "live_shrink_triggered",
+    "live_oos_proxy_ready",
+    "live_oos_proxy_train_rows",
+    "live_oos_proxy_bin_n",
+    "live_oos_proxy_bin_winrate",
+    "blocked_by",
+]
+
+
+def _sample_df() -> pd.DataFrame:
+    n_played = 420
+    n_upcoming = 6
+    dates_played = pd.date_range("2025-01-01", periods=n_played, freq="D")
+    dates_upcoming = pd.date_range("2026-03-10", periods=n_upcoming, freq="D")
+
+    pred_played = np.clip(np.linspace(0.38, 0.78, n_played), 0.01, 0.99)
+    win_played = (pred_played + np.sin(np.linspace(0, 8, n_played)) * 0.05 > 0.56).astype(int)
+
+    played = pd.DataFrame(
+        {
+            "game_date": dates_played,
+            "pred_home_win_proba": pred_played,
+            "home_team_prob": pred_played,
+            "home_team_won": win_played,
+            "result_raw": win_played,
+            "odds_1": np.where(pred_played > 0.55, 1.85, 2.45),
+            "odds_2": np.where(pred_played > 0.55, 1.98, 1.65),
+        }
+    )
+
+    pred_upcoming = np.array([0.41, 0.49, 0.55, 0.63, 0.67, 0.72])
+    upcoming = pd.DataFrame(
+        {
+            "game_date": dates_upcoming,
+            "pred_home_win_proba": pred_upcoming,
+            "home_team_prob": pred_upcoming,
+            "home_team_won": np.nan,
+            "result_raw": 0,
+            "odds_1": np.array([2.7, 2.2, 2.1, 1.95, 2.35, 2.55]),
+            "odds_2": np.array([1.52, 1.7, 1.82, 1.96, 1.62, 1.51]),
+        }
+    )
+    return pd.concat([played, upcoming], ignore_index=True)
+
+
+def verify_probability_parity() -> None:
+    base = _sample_df()
+    config = {
+        "date_col": "game_date",
+        "result_col": "home_team_won",
+        "result_raw_col": "result_raw",
+        "pred_proba_col": "pred_home_win_proba",
+        "today_date": pd.Timestamp("2026-03-10").date(),
+        "tomorrow_date": pd.Timestamp("2026-03-11").date(),
+        "compute_oos_chain": True,
+    }
+    script5_view = prepare_live_probability_columns(base, clip_lo=0.35, clip_hi=0.80, config=config)
+
+    ledger_input = script5_view.copy()
+    ledger_view = prepare_live_probability_columns(
+        ledger_input,
+        clip_lo=0.35,
+        clip_hi=0.80,
+        config={
+            "date_col": "game_date",
+            "result_col": "home_team_won",
+            "result_raw_col": "result_raw",
+            "pred_proba_col": "pred_home_win_proba",
+            "compute_oos_chain": False,
+        },
+    )
+
+    for c in KEY_COLS:
+        a = script5_view[c]
+        b = ledger_view[c]
+        if c == "blocked_by":
+            assert a.fillna("PASS").astype(str).equals(b.fillna("PASS").astype(str)), f"Mismatch in {c}"
+        elif a.dtype == bool or b.dtype == bool:
+            assert a.fillna(False).astype(bool).equals(b.fillna(False).astype(bool)), f"Mismatch in {c}"
+        else:
+            assert np.allclose(pd.to_numeric(a, errors="coerce").fillna(-9999), pd.to_numeric(b, errors="coerce").fillna(-9999), atol=1e-12), f"Mismatch in {c}"
+
+    for c in DEBUG_COLS:
+        assert c in script5_view.columns, f"Missing debug column {c}"
+        assert c in ledger_view.columns, f"Missing debug column {c} in ledger"
+
+
+def verify_strategy_param_loading() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        out = root / "2026" / "output" / "LightGBM"
+        out.mkdir(parents=True, exist_ok=True)
+
+        snapshot = {
+            "params_used_type": "LOCAL",
+            "params_used": {
+                "home_win_rate_threshold": 0.61,
+                "odds_min": 2.15,
+                "odds_max": 3.05,
+                "prob_threshold": 0.57,
+            },
+            "local_window_200": {"min_EV_applied": -4.0},
+        }
+        (out / "metrics_snapshot.json").write_text(json.dumps(snapshot), encoding="utf-8")
+
+        params = load_active_strategy_params(root)
+        assert params["home_win_rate_threshold"] == 0.61
+        assert params["odds_min"] == 2.15
+        assert params["odds_max"] == 3.05
+        assert params["prob_threshold"] == 0.57
+        assert params["min_ev"] == -4.0
+
+
+def verify_strategy_param_fallback() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        params = load_active_strategy_params(root)
+        assert params == {}, "Expected empty params when no files exist"
+
+
+if __name__ == "__main__":
+    verify_probability_parity()
+    verify_strategy_param_loading()
+    verify_strategy_param_fallback()
+    print("verify_pipeline_consistency: OK")

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -27,9 +27,7 @@ import pandas as pd
 from sklearn.isotonic import IsotonicRegression
 from sklearn.metrics import brier_score_loss, log_loss
 
-from live_calibration import compute_time_oos_isotonic
-from live_oos_proxy import apply_live_oos_proxy, build_live_oos_proxy
-from live_safety import apply_live_safety
+from live_probability_pipeline import prepare_live_probability_columns
 
 from nba_utils_2026 import (
     get_current_date,
@@ -515,68 +513,29 @@ def compute_calibration_metrics(df_past: pd.DataFrame) -> Tuple[float, float, fl
 
 
 def build_live_probability_columns(df_all: pd.DataFrame, today_date, tomorrow_date) -> tuple[pd.DataFrame, dict]:
-    df = df_all.copy()
-    played_mask = df[RESULT_RAW_COL].notna() & (df[RESULT_RAW_COL].astype(str) != "0")
-    upcoming_mask = (~played_mask) & df[DATE_COL].dt.date.isin([today_date, tomorrow_date])
-
-    df[PROB_ISO_OOS_TIME_COL] = compute_time_oos_isotonic(
-        df.loc[played_mask].copy(),
-        prob_col=PRED_PROBA_COL,
-        target_col=RESULT_COL,
-        date_col=DATE_COL,
-        min_train=MIN_TRAIN_OOS_TIME,
-        min_step=MIN_STEP_OOS_TIME,
+    df = prepare_live_probability_columns(
+        df_all,
+        clip_lo=PROB_CLIP_LO,
+        clip_hi=PROB_CLIP_HI,
+        config={
+            "date_col": DATE_COL,
+            "result_col": RESULT_COL,
+            "result_raw_col": RESULT_RAW_COL,
+            "pred_proba_col": PRED_PROBA_COL,
+            "prob_iso_oos_time_col": PROB_ISO_OOS_TIME_COL,
+            "min_train_oos_time": MIN_TRAIN_OOS_TIME,
+            "min_step_oos_time": MIN_STEP_OOS_TIME,
+            "min_train_oos_proxy": MIN_TRAIN_OOS_PROXY,
+            "today_date": today_date,
+            "tomorrow_date": tomorrow_date,
+            "compute_oos_chain": True,
+        },
     )
-
-    played_df = df.loc[played_mask].copy()
-    played_df["home_team_prob"] = pd.to_numeric(played_df[PRED_PROBA_COL], errors="coerce")
-    played_df["win"] = pd.to_numeric(played_df[RESULT_COL], errors="coerce")
-
-    proxy_obj = build_live_oos_proxy(
-        played_df,
-        prob_source_cols=[PROB_ISO_OOS_TIME_COL, "home_team_prob"],
-        target_col="win",
-        n_bins=25,
-        min_train_rows=MIN_TRAIN_OOS_PROXY,
-        min_bin_n=25,
-        use_wilson_lb=True,
-    )
-
-    df["live_oos_proxy_ready"] = bool(proxy_obj["ready"])
-    df["live_oos_proxy_train_rows"] = int(proxy_obj["train_rows"])
-    df["live_oos_proxy_bin_n"] = 0
-    df["live_oos_proxy_bin_winrate"] = np.nan
-
-    upcoming_df = df.loc[upcoming_mask].copy()
-    upcoming_df["home_team_prob"] = pd.to_numeric(upcoming_df[PRED_PROBA_COL], errors="coerce")
-    upcoming_with_proxy = apply_live_oos_proxy(upcoming_df, proxy_obj, in_col="home_team_prob")
-    for c in [
-        "prob_live_oos_proxy",
-        "live_oos_proxy_ready",
-        "live_oos_proxy_train_rows",
-        "live_oos_proxy_bin_n",
-        "live_oos_proxy_bin_winrate",
-    ]:
-        df.loc[upcoming_with_proxy.index, c] = upcoming_with_proxy[c]
-
-    logging.info(
-        "[LIVE OOS PROXY] ready=%s train_rows=%d win_rate=%.4f",
-        proxy_obj["ready"],
-        proxy_obj["train_rows"],
-        proxy_obj["global_win_rate"] if np.isfinite(proxy_obj["global_win_rate"]) else float("nan"),
-    )
-
-    safety_ready = bool(proxy_obj["ready"])
-    df = apply_live_safety(df, live_oos_proxy_ready=safety_ready)
-    df[PROB_LIVE_SAFE_COL] = df["prob_base"]
-
     meta = {
-        "live_oos_proxy_ready": bool(proxy_obj["ready"]),
-        "live_oos_proxy_train_rows": int(proxy_obj["train_rows"]),
+        "live_oos_proxy_ready": bool(pd.Series(df.get("live_oos_proxy_ready", False)).fillna(False).astype(bool).any()),
+        "live_oos_proxy_train_rows": int(pd.to_numeric(df.get("live_oos_proxy_train_rows", 0), errors="coerce").fillna(0).max() if isinstance(df.get("live_oos_proxy_train_rows", 0), pd.Series) else df.get("live_oos_proxy_train_rows", 0)),
     }
     return df, meta
-
-
 def run_self_test(df_all: pd.DataFrame, live_meta: dict | None = None) -> None:
     required_cols = [
         "home_team_prob", "prob_iso", PROB_ISO_OOS_TIME_COL, PROB_LIVE_OOS_PROXY_COL,

--- a/2026/src/live_probability_pipeline.py
+++ b/2026/src/live_probability_pipeline.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from live_calibration import compute_time_oos_isotonic
+from live_oos_proxy import apply_live_oos_proxy, build_live_oos_proxy
+from live_safety import apply_live_safety
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "date_col": "game_date",
+    "result_col": "home_team_won",
+    "result_raw_col": "result_raw",
+    "pred_proba_col": "pred_home_win_proba",
+    "prob_iso_oos_time_col": "prob_iso_oos_time",
+    "prob_live_oos_proxy_col": "prob_live_oos_proxy",
+    "min_train_oos_time": 50,
+    "min_step_oos_time": 10,
+    "min_train_oos_proxy": 300,
+    "proxy_n_bins": 25,
+    "proxy_min_bin_n": 25,
+    "today_date": None,
+    "tomorrow_date": None,
+    "compute_oos_chain": True,
+}
+
+
+def _read_strategy_params_txt(path: Path) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+    if not path.exists():
+        return params
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        key = k.strip()
+        raw = v.strip()
+        try:
+            val: Any = float(raw)
+        except ValueError:
+            val = raw
+        params[key] = val
+    return params
+
+
+def _extract_strategy_params(payload: dict[str, Any]) -> dict[str, Any]:
+    params = payload.get("params_used") if isinstance(payload, dict) else None
+    if not isinstance(params, dict):
+        return {}
+
+    out = {
+        "home_win_rate_threshold": params.get("home_win_rate_threshold"),
+        "odds_min": params.get("odds_min"),
+        "odds_max": params.get("odds_max"),
+        "prob_threshold": params.get("prob_threshold"),
+    }
+    if "min_ev" in params:
+        out["min_ev"] = params.get("min_ev")
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def load_active_strategy_params(repo_root: Path) -> dict[str, Any]:
+    env_override = os.environ.get("STRATEGY_PARAMS_PATH", "").strip()
+    if env_override:
+        override_path = Path(env_override)
+        if override_path.exists() and override_path.suffix.lower() == ".json":
+            try:
+                payload = json.loads(override_path.read_text(encoding="utf-8"))
+                params = _extract_strategy_params(payload)
+                if params:
+                    return params
+            except json.JSONDecodeError:
+                pass
+        if override_path.exists():
+            params = _read_strategy_params_txt(override_path)
+            if params:
+                return params
+
+    metrics_candidates = [
+        repo_root / "2026" / "output" / "LightGBM" / "metrics_snapshot.json",
+        repo_root / "2026" / "output" / "LightGBM" / "Kelly" / "metrics_snapshot.json",
+    ]
+    for path in metrics_candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        params = _extract_strategy_params(payload)
+        if params:
+            if "min_ev" not in params:
+                local = payload.get("local_window_200", {}) if isinstance(payload, dict) else {}
+                if isinstance(local, dict) and "min_EV_applied" in local:
+                    params["min_ev"] = local.get("min_EV_applied")
+            return params
+
+    txt_candidates = [
+        repo_root / "2026" / "output" / "LightGBM" / "strategy_params.txt",
+        repo_root / "2026" / "output" / "LightGBM" / "Kelly" / "strategy_params.txt",
+    ]
+    for path in txt_candidates:
+        params = _read_strategy_params_txt(path)
+        if not params:
+            continue
+        mapped = {
+            "home_win_rate_threshold": params.get("home_win_rate_threshold"),
+            "odds_min": params.get("odds_min"),
+            "odds_max": params.get("odds_max"),
+            "prob_threshold": params.get("prob_threshold"),
+        }
+        if "min_ev" in params:
+            mapped["min_ev"] = params.get("min_ev")
+        return {k: v for k, v in mapped.items() if v is not None}
+
+    return {}
+
+
+def prepare_live_probability_columns(
+    df: pd.DataFrame,
+    *,
+    clip_lo: float,
+    clip_hi: float,
+    config: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    out = df.copy()
+
+    date_col = cfg["date_col"]
+    result_col = cfg["result_col"]
+    result_raw_col = cfg["result_raw_col"]
+    pred_proba_col = cfg["pred_proba_col"]
+    prob_iso_oos_time_col = cfg["prob_iso_oos_time_col"]
+
+    out["home_team_prob"] = pd.to_numeric(out.get("home_team_prob", out.get(pred_proba_col)), errors="coerce")
+    out["prob_iso"] = pd.to_numeric(out.get("prob_iso", out.get("iso_proba_home_win")), errors="coerce")
+
+    if "odds_1" not in out.columns and "closing_home_odds" in out.columns:
+        out["odds_1"] = pd.to_numeric(out["closing_home_odds"], errors="coerce")
+    if "odds_2" not in out.columns and "closing_away_odds" in out.columns:
+        out["odds_2"] = pd.to_numeric(out["closing_away_odds"], errors="coerce")
+
+    played_mask = out[result_raw_col].notna() & (out[result_raw_col].astype(str) != "0") if result_raw_col in out.columns else out[result_col].notna()
+
+    if cfg["compute_oos_chain"] and date_col in out.columns and result_col in out.columns:
+        out[date_col] = pd.to_datetime(out[date_col], errors="coerce")
+        out[prob_iso_oos_time_col] = compute_time_oos_isotonic(
+            out.loc[played_mask].copy(),
+            prob_col=pred_proba_col,
+            target_col=result_col,
+            date_col=date_col,
+            min_train=int(cfg["min_train_oos_time"]),
+            min_step=int(cfg["min_step_oos_time"]),
+        )
+
+        played_df = out.loc[played_mask].copy()
+        played_df["home_team_prob"] = pd.to_numeric(played_df["home_team_prob"], errors="coerce")
+        played_df["win"] = pd.to_numeric(played_df[result_col], errors="coerce")
+        proxy_obj = build_live_oos_proxy(
+            played_df,
+            prob_source_cols=[prob_iso_oos_time_col, "home_team_prob"],
+            target_col="win",
+            n_bins=int(cfg["proxy_n_bins"]),
+            min_train_rows=int(cfg["min_train_oos_proxy"]),
+            min_bin_n=int(cfg["proxy_min_bin_n"]),
+            use_wilson_lb=True,
+        )
+
+        out["live_oos_proxy_ready"] = bool(proxy_obj["ready"])
+        out["live_oos_proxy_train_rows"] = int(proxy_obj["train_rows"])
+        out["live_oos_proxy_bin_n"] = 0
+        out["live_oos_proxy_bin_winrate"] = np.nan
+
+        upcoming_mask = (~played_mask)
+        today_date = cfg.get("today_date")
+        tomorrow_date = cfg.get("tomorrow_date")
+        if today_date is not None and tomorrow_date is not None and date_col in out.columns:
+            upcoming_mask = upcoming_mask & out[date_col].dt.date.isin([today_date, tomorrow_date])
+
+        upcoming_df = out.loc[upcoming_mask].copy()
+        upcoming_df["home_team_prob"] = pd.to_numeric(upcoming_df["home_team_prob"], errors="coerce")
+        upcoming_with_proxy = apply_live_oos_proxy(upcoming_df, proxy_obj, in_col="home_team_prob")
+        for c in [
+            "prob_live_oos_proxy",
+            "live_oos_proxy_ready",
+            "live_oos_proxy_train_rows",
+            "live_oos_proxy_bin_n",
+            "live_oos_proxy_bin_winrate",
+        ]:
+            out.loc[upcoming_with_proxy.index, c] = upcoming_with_proxy[c]
+    else:
+        out[prob_iso_oos_time_col] = pd.to_numeric(out.get(prob_iso_oos_time_col, np.nan), errors="coerce")
+        out["prob_live_oos_proxy"] = pd.to_numeric(out.get("prob_live_oos_proxy", np.nan), errors="coerce")
+
+    proxy_ready_col = out.get("live_oos_proxy_ready", False)
+    if isinstance(proxy_ready_col, pd.Series):
+        live_oos_proxy_ready = bool(proxy_ready_col.fillna(False).astype(bool).any())
+    else:
+        live_oos_proxy_ready = bool(proxy_ready_col)
+
+    out = apply_live_safety(out, live_oos_proxy_ready=live_oos_proxy_ready)
+    out["prob_live_safe"] = out["prob_base"]
+    out["prob_used"] = pd.to_numeric(out["prob_used"], errors="coerce").clip(clip_lo, clip_hi)
+
+    for c in [
+        "prob_base",
+        "prob_live_safe_pre_clip",
+        "prob_live_oos_proxy",
+        "market_implied_p_raw",
+        "market_implied_p_devig",
+        "model_market_gap",
+        "model_market_gap_flag",
+        "live_underdog_upscale_guard_triggered",
+        "live_shrink_triggered",
+        "live_oos_proxy_ready",
+        "live_oos_proxy_train_rows",
+        "live_oos_proxy_bin_n",
+        "live_oos_proxy_bin_winrate",
+        "blocked_by",
+    ]:
+        if c not in out.columns:
+            out[c] = np.nan
+
+    return out


### PR DESCRIPTION
### Motivation
- Remove duplicated live probability/transformation logic and ensure Script 5 and the live ledger use one canonical implementation for parity and maintainability. 
- Replace hard-coded ledger bet filters with dynamically-generated strategy parameters discovered by Script 5 so live qualification matches the strategy search. 

### Description
- Added a shared module `2026/src/live_probability_pipeline.py` that exposes `prepare_live_probability_columns(...)` (canonical probability chain: normalization, time-OOS isotonic, live OOS proxy, market implied probabilities, model/market gap, underdog guard, shrink/blend, final clipping) and `load_active_strategy_params(repo_root)` (loads active strategy params from `STRATEGY_PARAMS_PATH` override → `metrics_snapshot.json` → `strategy_params.txt`).
- Refactored `2026/src/5_Isotonic_based_betting_strategy_2026.py` to call `prepare_live_probability_columns(...)` for live/historical prob columns and to return the same debug columns used downstream (`prob_base`, `prob_live_safe_pre_clip`, `market_implied_p_raw`, `model_market_gap`, `model_market_gap_flag`, `blocked_by`, etc.).
- Refactored `2026/scripts/maintain_bet_log_flat_live.py` to call `prepare_live_probability_columns(...)` inside `_prepare_combined(...)`, use `load_active_strategy_params(...)` in `main()`, and apply the loaded thresholds in `_append_new_bets(...)` while safely falling back to legacy constants when params are absent; kept ledger hard-veto (`blocked_by` / `model_market_gap_flag`) and stake behavior unchanged.
- Added verification script `2026/scripts/verify_pipeline_consistency.py` which asserts parity between Script 5 and ledger for `prob_used`, `model_market_gap`, `model_market_gap_flag`, and `blocked_by`, verifies strategy param loading from `metrics_snapshot.json`, and verifies fallback behavior when no params files exist.
- Files added: `2026/src/live_probability_pipeline.py`, `2026/scripts/verify_pipeline_consistency.py`; Files changed: `2026/src/5_Isotonic_based_betting_strategy_2026.py`, `2026/scripts/maintain_bet_log_flat_live.py`; Duplicate ledger-side probability math removed and replaced by the shared pipeline call.

### Testing
- Ran syntax checks with `python -m py_compile 2026/src/*.py 2026/scripts/*.py` which completed successfully. 
- Ran `python 2026/scripts/verify_pipeline_consistency.py` which executed the parity and loader checks and printed success (`verify_pipeline_consistency: OK`).
- All automated checks passed; the verification script confirms parity for representative rows and confirms strategy param loading and fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b70c4a93388331a560c9e397fd486f)