### PR TITLE
Centralize 2026 live probability chain and require Script 5 strategy thresholds for live ledger

### DIFF
--- a/2026/scripts/maintain_bet_log_flat_live.py
+++ b/2026/scripts/maintain_bet_log_flat_live.py
@@ -14,17 +14,12 @@ SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from live_probability_pipeline import load_active_strategy_params, prepare_live_probability_columns
+from live_probability_pipeline import build_probability_chain_config, load_required_strategy_params, prepare_live_probability_columns
 
 
 PROB_CLIP_LO = 0.35
 PROB_CLIP_HI = 0.80
-MIN_EV = -5
 STAKE = 100
-ODDS_MIN = 2.10
-ODDS_MAX = 3.10
-HOME_WIN_RATE_MIN = 0.55
-PROB_MIN = 0.40
 UNDERDOG_ODDS_GUARD_MIN = 2.00
 UNDERDOG_PROB_GUARD_MIN = 0.60
 GAP_GUARD_MIN = 0.12
@@ -262,14 +257,14 @@ def _prepare_combined(df: pd.DataFrame) -> pd.DataFrame:
         combined,
         clip_lo=PROB_CLIP_LO,
         clip_hi=PROB_CLIP_HI,
-        config={
-            "date_col": "game_date",
-            "result_col": "home_team_won",
-            "result_raw_col": "result_raw",
-            "pred_proba_col": "pred_home_win_proba",
-            "prob_iso_oos_time_col": "prob_iso_oos_time",
-            "compute_oos_chain": False,
-        },
+        config=build_probability_chain_config(
+            date_col="game_date",
+            result_col="home_team_won",
+            result_raw_col="result_raw",
+            pred_proba_col="pred_home_win_proba",
+            prob_iso_oos_time_col="prob_iso_oos_time",
+            compute_oos_chain=False,
+        ),
     )
 
     if columns.home_win_rate:
@@ -391,16 +386,15 @@ def _dedupe_ledger(ledger: pd.DataFrame) -> pd.DataFrame:
     return ledger.drop_duplicates(subset=["game_key"], keep="first")
 
 
-def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame, params: dict[str, float] | None = None) -> pd.DataFrame:
+def _append_new_bets(ledger: pd.DataFrame, combined: pd.DataFrame, params: dict[str, float]) -> pd.DataFrame:
     existing_keys = set(ledger["game_key"].dropna())
 
     upcoming = combined[combined["win"].isna()].copy()
-    active = params or {}
-    home_win_rate_min = float(active.get("home_win_rate_threshold", HOME_WIN_RATE_MIN))
-    odds_min = float(active.get("odds_min", ODDS_MIN))
-    odds_max = float(active.get("odds_max", ODDS_MAX))
-    prob_min = float(active.get("prob_threshold", PROB_MIN))
-    min_ev = float(active.get("min_ev", MIN_EV))
+    home_win_rate_min = float(params["home_win_rate_threshold"])
+    odds_min = float(params["odds_min"])
+    odds_max = float(params["odds_max"])
+    prob_min = float(params["prob_threshold"])
+    min_ev = float(params["min_ev"])
 
     qualifiers = upcoming[
         (upcoming["home_win_rate"] >= home_win_rate_min)
@@ -512,7 +506,7 @@ def main() -> None:
 
     ledger = _load_ledger(ledger_path)
     ledger = _settle_pending_bets(ledger, combined)
-    active_params = load_active_strategy_params(repo_root)
+    active_params = load_required_strategy_params(repo_root)
     ledger = _append_new_bets(ledger, combined, params=active_params)
     ledger = _dedupe_ledger(ledger)
 

--- a/2026/scripts/verify_pipeline_consistency.py
+++ b/2026/scripts/verify_pipeline_consistency.py
@@ -13,7 +13,12 @@ SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from live_probability_pipeline import load_active_strategy_params, prepare_live_probability_columns
+from live_probability_pipeline import (
+    build_probability_chain_config,
+    load_active_strategy_params,
+    load_required_strategy_params,
+    prepare_live_probability_columns,
+)
 
 
 KEY_COLS = ["prob_used", "model_market_gap", "model_market_gap_flag", "blocked_by"]
@@ -73,15 +78,15 @@ def _sample_df() -> pd.DataFrame:
 
 def verify_probability_parity() -> None:
     base = _sample_df()
-    config = {
-        "date_col": "game_date",
-        "result_col": "home_team_won",
-        "result_raw_col": "result_raw",
-        "pred_proba_col": "pred_home_win_proba",
-        "today_date": pd.Timestamp("2026-03-10").date(),
-        "tomorrow_date": pd.Timestamp("2026-03-11").date(),
-        "compute_oos_chain": True,
-    }
+    config = build_probability_chain_config(
+        date_col="game_date",
+        result_col="home_team_won",
+        result_raw_col="result_raw",
+        pred_proba_col="pred_home_win_proba",
+        today_date=pd.Timestamp("2026-03-10").date(),
+        tomorrow_date=pd.Timestamp("2026-03-11").date(),
+        compute_oos_chain=True,
+    )
     script5_view = prepare_live_probability_columns(base, clip_lo=0.35, clip_hi=0.80, config=config)
 
     ledger_input = script5_view.copy()
@@ -89,13 +94,13 @@ def verify_probability_parity() -> None:
         ledger_input,
         clip_lo=0.35,
         clip_hi=0.80,
-        config={
-            "date_col": "game_date",
-            "result_col": "home_team_won",
-            "result_raw_col": "result_raw",
-            "pred_proba_col": "pred_home_win_proba",
-            "compute_oos_chain": False,
-        },
+        config=build_probability_chain_config(
+            date_col="game_date",
+            result_col="home_team_won",
+            result_raw_col="result_raw",
+            pred_proba_col="pred_home_win_proba",
+            compute_oos_chain=False,
+        ),
     )
 
     for c in KEY_COLS:
@@ -132,12 +137,28 @@ def verify_strategy_param_loading() -> None:
         (out / "metrics_snapshot.json").write_text(json.dumps(snapshot), encoding="utf-8")
 
         params = load_active_strategy_params(root)
+        required = load_required_strategy_params(root)
         assert params["home_win_rate_threshold"] == 0.61
+        assert required["home_win_rate_threshold"] == 0.61
         assert params["odds_min"] == 2.15
         assert params["odds_max"] == 3.05
         assert params["prob_threshold"] == 0.57
         assert params["min_ev"] == -4.0
 
+
+
+
+def verify_required_strategy_param_failure() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        out = root / "2026" / "output" / "LightGBM"
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "strategy_params.txt").write_text("home_win_rate_threshold=0.6\nodds_min=2.1\n", encoding="utf-8")
+        try:
+            load_required_strategy_params(root)
+        except RuntimeError:
+            return
+        raise AssertionError("Expected RuntimeError for missing required strategy thresholds")
 
 def verify_strategy_param_fallback() -> None:
     with tempfile.TemporaryDirectory() as tmp:
@@ -149,5 +170,6 @@ def verify_strategy_param_fallback() -> None:
 if __name__ == "__main__":
     verify_probability_parity()
     verify_strategy_param_loading()
+    verify_required_strategy_param_failure()
     verify_strategy_param_fallback()
     print("verify_pipeline_consistency: OK")

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -27,7 +27,7 @@ import pandas as pd
 from sklearn.isotonic import IsotonicRegression
 from sklearn.metrics import brier_score_loss, log_loss
 
-from live_probability_pipeline import prepare_live_probability_columns
+from live_probability_pipeline import build_probability_chain_config, prepare_live_probability_columns
 
 from nba_utils_2026 import (
     get_current_date,
@@ -517,19 +517,19 @@ def build_live_probability_columns(df_all: pd.DataFrame, today_date, tomorrow_da
         df_all,
         clip_lo=PROB_CLIP_LO,
         clip_hi=PROB_CLIP_HI,
-        config={
-            "date_col": DATE_COL,
-            "result_col": RESULT_COL,
-            "result_raw_col": RESULT_RAW_COL,
-            "pred_proba_col": PRED_PROBA_COL,
-            "prob_iso_oos_time_col": PROB_ISO_OOS_TIME_COL,
-            "min_train_oos_time": MIN_TRAIN_OOS_TIME,
-            "min_step_oos_time": MIN_STEP_OOS_TIME,
-            "min_train_oos_proxy": MIN_TRAIN_OOS_PROXY,
-            "today_date": today_date,
-            "tomorrow_date": tomorrow_date,
-            "compute_oos_chain": True,
-        },
+        config=build_probability_chain_config(
+            date_col=DATE_COL,
+            result_col=RESULT_COL,
+            result_raw_col=RESULT_RAW_COL,
+            pred_proba_col=PRED_PROBA_COL,
+            prob_iso_oos_time_col=PROB_ISO_OOS_TIME_COL,
+            min_train_oos_time=MIN_TRAIN_OOS_TIME,
+            min_step_oos_time=MIN_STEP_OOS_TIME,
+            min_train_oos_proxy=MIN_TRAIN_OOS_PROXY,
+            today_date=today_date,
+            tomorrow_date=tomorrow_date,
+            compute_oos_chain=True,
+        ),
     )
     meta = {
         "live_oos_proxy_ready": bool(pd.Series(df.get("live_oos_proxy_ready", False)).fillna(False).astype(bool).any()),

--- a/2026/src/live_probability_pipeline.py
+++ b/2026/src/live_probability_pipeline.py
@@ -29,6 +29,14 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "compute_oos_chain": True,
 }
 
+REQUIRED_STRATEGY_PARAM_KEYS = (
+    "home_win_rate_threshold",
+    "odds_min",
+    "odds_max",
+    "prob_threshold",
+    "min_ev",
+)
+
 
 def _read_strategy_params_txt(path: Path) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -121,6 +129,57 @@ def load_active_strategy_params(repo_root: Path) -> dict[str, Any]:
         return {k: v for k, v in mapped.items() if v is not None}
 
     return {}
+
+
+def load_required_strategy_params(repo_root: Path) -> dict[str, float]:
+    """
+    Load active strategy thresholds from Script 5 artifacts and enforce key presence.
+    """
+    params = load_active_strategy_params(repo_root)
+    missing = [k for k in REQUIRED_STRATEGY_PARAM_KEYS if k not in params]
+    if missing:
+        raise RuntimeError(
+            "Missing required strategy thresholds from Script 5 outputs "
+            f"(metrics_snapshot.json / strategy_params.txt): {missing}"
+        )
+    return {k: float(params[k]) for k in REQUIRED_STRATEGY_PARAM_KEYS}
+
+
+
+
+def build_probability_chain_config(
+    *,
+    date_col: str,
+    result_col: str,
+    result_raw_col: str,
+    pred_proba_col: str,
+    prob_iso_oos_time_col: str = "prob_iso_oos_time",
+    compute_oos_chain: bool,
+    min_train_oos_time: int | None = None,
+    min_step_oos_time: int | None = None,
+    min_train_oos_proxy: int | None = None,
+    today_date=None,
+    tomorrow_date=None,
+) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "date_col": date_col,
+        "result_col": result_col,
+        "result_raw_col": result_raw_col,
+        "pred_proba_col": pred_proba_col,
+        "prob_iso_oos_time_col": prob_iso_oos_time_col,
+        "compute_oos_chain": bool(compute_oos_chain),
+    }
+    if min_train_oos_time is not None:
+        cfg["min_train_oos_time"] = int(min_train_oos_time)
+    if min_step_oos_time is not None:
+        cfg["min_step_oos_time"] = int(min_step_oos_time)
+    if min_train_oos_proxy is not None:
+        cfg["min_train_oos_proxy"] = int(min_train_oos_proxy)
+    if today_date is not None:
+        cfg["today_date"] = today_date
+    if tomorrow_date is not None:
+        cfg["tomorrow_date"] = tomorrow_date
+    return cfg
 
 
 def prepare_live_probability_columns(


### PR DESCRIPTION
### Motivation
- Remove duplicated live-probability chain configuration between Script 5 and the live ledger so both consumers share a single, explicit config builder. 
- Make the live ledger stop relying on hard-coded threshold fallbacks and instead load the active strategy thresholds produced by Script 5 artifacts (`metrics_snapshot.json` / `strategy_params.txt`).
- Add a parity/verification check to ensure Script 5 and ledger views remain consistent after centralization and to assert failure when required thresholds are incomplete.

### Description
- Added `build_probability_chain_config(...)` and `load_required_strategy_params(...)` helpers to `2026/src/live_probability_pipeline.py` to centralize chain configuration and to enforce presence of required strategy thresholds. 
- Updated Script 5 to use the shared config builder by calling `build_probability_chain_config(...)` when building live probability columns. 
- Updated the live ledger maintainer to call `load_required_strategy_params(...)` (removing hard-coded threshold fallbacks) and to use `build_probability_chain_config(...)` for the ledger path; the ledger output schema (`LEDGER_COLUMNS`) is preserved. 
- Extended the parity/consistency script to use the new config helper and to add a test (`verify_required_strategy_param_failure`) which asserts that `load_required_strategy_params(...)` raises when thresholds are incomplete; files changed: `2026/src/live_probability_pipeline.py`, `2026/src/5_Isotonic_based_betting_strategy_2026.py`, `2026/scripts/maintain_bet_log_flat_live.py`, and `2026/scripts/verify_pipeline_consistency.py`.

### Testing
- Ran byte-compile on modified modules with `python -m py_compile 2026/src/live_probability_pipeline.py 2026/src/5_Isotonic_based_betting_strategy_2026.py 2026/scripts/maintain_bet_log_flat_live.py 2026/scripts/verify_pipeline_consistency.py` and the command completed without errors. 
- Executed the parity and strategy-param verification script with `python 2026/scripts/verify_pipeline_consistency.py` which prints `verify_pipeline_consistency: OK`, indicating parity checks and required-params tests passed. 
- The new verification includes both parity comparisons of key columns (`prob_used`, `model_market_gap`, `model_market_gap_flag`, `blocked_by`) and a failure case asserting `load_required_strategy_params(...)` raises when required thresholds are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b70e7f779483318dbde045bac8af09)