### PR TITLE
Queue same-ref BP workflow runs by switching concurrency to workflow+ref (no cancel)

### DIFF
--- a/.github/workflows/1_get_data_previous_game_day_2026.yml
+++ b/.github/workflows/1_get_data_previous_game_day_2026.yml
@@ -4,8 +4,8 @@ permissions:
   contents: write
 
 concurrency:
-  group: nba-collect-previous-game
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 on:
   schedule:


### PR DESCRIPTION
### Motivation
- Prevent same-ref overlapping runs and race conditions when the Basketball_prediction workflow can be triggered both by its schedule and by an external dispatch, by ensuring a second trigger queues rather than runs in parallel or cancels the first run.

### Description
- Update the workflow-level `concurrency` in `.github/workflows/1_get_data_previous_game_day_2026.yml` to `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: false`, leaving schedule, `workflow_dispatch`, job steps, and business logic unchanged.

### Testing
- Verified the change and recorded it with `git diff -- .github/workflows/1_get_data_previous_game_day_2026.yml`, `git status --short`, and `git commit -m "Adjust BP data workflow concurrency to queue overlapping runs"`, and those commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c958f637d88331bc8e6a0ce6520d41)