### PR TITLE
Fix home win rate merge duplicate-column crash

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -516,6 +516,7 @@ def attach_home_win_rate(df: pd.DataFrame, hwr_path: str) -> pd.DataFrame:
         df[HOMEWR_COL] = 0.0
         return df
 
+    base_df = df.drop(columns=[HOMEWR_COL], errors="ignore").copy()
     hwr = pd.read_csv(hwr_path, encoding="utf-8")
     cols = list(hwr.columns)
 
@@ -532,10 +533,10 @@ def attach_home_win_rate(df: pd.DataFrame, hwr_path: str) -> pd.DataFrame:
         win_col = next((c for c in cols if "win rate" in c.lower()), cols[-1])
 
     hwr["_team_norm"] = hwr[team_col].astype(str).str.strip().map(normalize_team_code)
-    df["_home_team_norm"] = df["home_team"].astype(str).str.strip().map(normalize_team_code)
+    base_df["_home_team_norm"] = base_df["home_team"].astype(str).str.strip().map(normalize_team_code)
 
     hwr_m = hwr[["_team_norm", win_col]].drop_duplicates("_team_norm")
-    out = df.merge(hwr_m, left_on="_home_team_norm", right_on="_team_norm", how="left")
+    out = base_df.merge(hwr_m, left_on="_home_team_norm", right_on="_team_norm", how="left")
 
     out.rename(columns={win_col: HOMEWR_COL}, inplace=True)
     out[HOMEWR_COL] = pd.to_numeric(out[HOMEWR_COL], errors="coerce").fillna(0.0)


### PR DESCRIPTION
### Motivation
- Prevent a crash in Script 5 where merging computed home win rates onto the games dataframe could create duplicate `home_win_rate` columns and cause `pd.to_numeric(...)` to receive a DataFrame (raising a `TypeError`).

### Description
- Drop any existing `HOMEWR_COL` from the input dataframe before merging by creating `base_df = df.drop(columns=[HOMEWR_COL], errors="ignore").copy()` in `attach_home_win_rate` in `2026/src/5_Isotonic_based_betting_strategy_2026.py`.
- Compute `_home_team_norm` on `base_df` and perform the left merge against `hwr_m` using `base_df` so the merged result produces a single `HOMEWR_COL` column.
- Ensure `out[HOMEWR_COL]` is a single Series before calling `pd.to_numeric(...).fillna(0.0)`, avoiding the prior `TypeError`.

### Testing
- Ran `python -m py_compile 2026/src/5_Isotonic_based_betting_strategy_2026.py`, which completed successfully.
- Executed an import-based runtime smoke snippet to validate behavior, but it failed with `ModuleNotFoundError: No module named 'live_probability_pipeline'` due to environment dependencies, so full runtime validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc129ec18c83318001c78b72f2d81a)