### PR TITLE
Graceful handling of missing isotonic training rows and backfill for result column

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -403,11 +403,15 @@ def load_combined_df(pred_dir: str, ymd: str) -> pd.DataFrame:
 
     if RESULT_COL not in df.columns:
         df[RESULT_COL] = np.nan
-        if "home_team" in df.columns and "result" in df.columns:
-            mask = df["result"].notna() & (df["result"].astype(str) != "0")
-            df.loc[mask, RESULT_COL] = (
-                df.loc[mask, "result"].astype(str) == df.loc[mask, "home_team"].astype(str)
-            ).astype(int)
+    if "home_team" in df.columns and "result" in df.columns:
+        mask = (
+            df["result"].notna()
+            & (df["result"].astype(str) != "0")
+            & df[RESULT_COL].isna()
+        )
+        df.loc[mask, RESULT_COL] = (
+            df.loc[mask, "result"].astype(str) == df.loc[mask, "home_team"].astype(str)
+        ).astype(int)
 
     return df
 
@@ -565,10 +569,11 @@ def split_past_future(df_all: pd.DataFrame, today_date, tomorrow_date) -> Tuple[
 # ISOTONIC / METRICS
 # -----------------------------
 
-def fit_isotonic(df_past: pd.DataFrame) -> IsotonicRegression:
+def fit_isotonic(df_past: pd.DataFrame) -> Optional[IsotonicRegression]:
     m = df_past[RESULT_COL].notna() & df_past[PRED_PROBA_COL].notna()
     if m.sum() == 0:
-        raise RuntimeError("No valid rows for isotonic fit.")
+        logging.warning("No valid rows for isotonic fit; using base probabilities.")
+        return None
     y = df_past.loc[m, RESULT_COL].astype(int).values
     p = df_past.loc[m, PRED_PROBA_COL].astype(float).values
     iso = IsotonicRegression(out_of_bounds="clip")


### PR DESCRIPTION
### Motivation
- Prevent the betting pipeline from crashing when there are zero valid (result, probability) rows for isotonic calibration. 
- Ensure historical played games are usable for calibration when the `RESULT_COL` already exists but contains nulls. 
- Preserve the existing fallback to base probabilities when isotonic fitting is not possible.

### Description
- Updated `load_combined_df` to backfill `RESULT_COL` (`home_team_won`) from `result`/`home_team` only for rows where `RESULT_COL` is missing or null (keeps already-populated values intact). 
- Changed `fit_isotonic` return type to `Optional[IsotonicRegression]` and made it return `None` with a `logging.warning` when no valid training rows are available instead of raising `RuntimeError`. 
- Left downstream logic intact so the `iso is None` path continues to use base probabilities and existing fallbacks.

### Testing
- Performed a syntax check with `python -m py_compile 2026/src/5_Isotonic_based_betting_strategy_2026.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1190547f483319dfaca9213fc4d3e)