### PR TITLE
Normalize dated local_matched_games CSV `date` column and add strict validation

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -88,6 +88,17 @@ OUTPUT_BASE_COLUMNS = [
     "accuracy",
 ]
 
+DATE_SOURCE_CANDIDATES = [
+    "date",
+    DATE_COL,
+    "game_date",
+    "date_x",
+    "Date",
+    "DATE",
+    "datetime",
+    "timestamp",
+]
+
 OUTPUT_PROBABILITY_COLUMNS = [
     "prob_iso",
     "prob_iso_insample",
@@ -791,10 +802,25 @@ def find_best_local_params_lastN(
 
 def prepare_local_matched_export(matched_subset: pd.DataFrame, stake: float) -> pd.DataFrame:
     df = matched_subset.copy()
-    if "date" not in df.columns:
-        df["date"] = df[DATE_COL]
-    df = _ensure_datetime(df, "date")
-    df["date"] = df["date"].dt.strftime("%Y-%m-%d")
+    date_source_col = next((c for c in DATE_SOURCE_CANDIDATES if c in df.columns), None)
+    if date_source_col is None:
+        raise RuntimeError(
+            "local_matched_games dated export missing required date column "
+            f"(checked candidates={DATE_SOURCE_CANDIDATES})"
+        )
+    parsed_dates = pd.to_datetime(df[date_source_col], errors="coerce")
+    valid_date_mask = parsed_dates.notna()
+    invalid_count = int((~valid_date_mask).sum())
+    if invalid_count > 0:
+        logging.warning(
+            "Dropping %d local_matched rows with invalid %s values during date normalization.",
+            invalid_count,
+            date_source_col,
+        )
+    df = df.loc[valid_date_mask].copy()
+    if df.empty:
+        raise RuntimeError("local_matched_games dated export has 0 valid date rows after normalization")
+    df["date"] = parsed_dates.loc[valid_date_mask].dt.strftime("%Y-%m-%d")
 
     if "home_win_rate" not in df.columns:
         df["home_win_rate"] = df[HOMEWR_COL]
@@ -982,9 +1008,40 @@ def write_local_matched_artifacts(export_df: pd.DataFrame, *, as_of_date: str, o
     output_dir.mkdir(parents=True, exist_ok=True)
     dated_path = output_dir / f"local_matched_games_{as_of_date}.csv"
     latest_path = output_dir / "local_matched_games_latest.csv"
-    export_df.to_csv(dated_path, index=False, encoding="utf-8")
+    normalized_df = export_df.copy()
+    date_source_col = next((c for c in DATE_SOURCE_CANDIDATES if c in normalized_df.columns), None)
+    if date_source_col is None:
+        raise RuntimeError("local_matched_games dated export missing required date column")
+    parsed_dates = pd.to_datetime(normalized_df[date_source_col], errors="coerce")
+    valid_mask = parsed_dates.notna()
+    dropped = int((~valid_mask).sum())
+    if dropped:
+        logging.warning(
+            "Dropping %d invalid local_matched rows before writing artifacts (date source=%s).",
+            dropped,
+            date_source_col,
+        )
+    normalized_df = normalized_df.loc[valid_mask].copy()
+    if normalized_df.empty:
+        raise RuntimeError("local_matched_games dated export has 0 valid date rows after normalization")
+    normalized_df["date"] = parsed_dates.loc[valid_mask].dt.strftime("%Y-%m-%d")
+    if normalized_df["date"].isna().any():
+        raise RuntimeError("local_matched_games dated export has null date values after normalization")
+
+    logging.info("local_matched export output path: %s", dated_path)
+    logging.info("local_matched export date source column: %s", date_source_col)
+    logging.info("local_matched export columns: %s", list(normalized_df.columns))
+    logging.info("local_matched export head(3):\n%s", normalized_df.head(3).to_string(index=False))
+    logging.info(
+        "local_matched export non-null date=%d valid parsed=%d rows=%d",
+        int(normalized_df["date"].notna().sum()),
+        int(pd.to_datetime(normalized_df["date"], errors="coerce").notna().sum()),
+        int(len(normalized_df)),
+    )
+
+    normalized_df.to_csv(dated_path, index=False, encoding="utf-8")
     shutil.copyfile(dated_path, latest_path)
-    logging.info("Saved %s (%d rows)", dated_path, len(export_df))
+    logging.info("Saved %s (%d rows)", dated_path, len(normalized_df))
     logging.info("Updated %s -> mirror of %s", latest_path, dated_path.name)
 
 
@@ -1012,6 +1069,16 @@ def validate_dated_dashboard_artifacts(*, output_dir: Path, as_of_date: str) -> 
 
     if matched_dated.read_text(encoding="utf-8") != matched_latest.read_text(encoding="utf-8"):
         raise RuntimeError("Validation failed. local_matched_games_latest.csv does not mirror dated local_matched file.")
+
+    matched_df = pd.read_csv(matched_dated)
+    if "date" not in matched_df.columns:
+        raise RuntimeError("local_matched_games dated export missing required date column")
+    valid_dates = pd.to_datetime(matched_df["date"], errors="coerce").notna()
+    valid_date_count = int(valid_dates.sum())
+    if valid_date_count <= 0:
+        raise RuntimeError("local_matched_games dated export has 0 valid date rows after normalization")
+    if not valid_dates.all():
+        raise RuntimeError("local_matched_games dated export includes invalid date rows after normalization")
 
     logging.info("Validated dated dashboard artifacts for as_of_date=%s", as_of_date)
     logging.info("- %s", matched_dated)


### PR DESCRIPTION
### Motivation
- CI for downstream validation failed with `local_matched_games has no valid date rows`, indicating the dated CSVs sometimes contained either no parseable dates or an unexpected schema. 
- Make Script 5 produce a deterministic, hoops-insight-compatible schema by ensuring a canonical `date` column in `YYYY-MM-DD` format and surfacing problems early. 
- Add debug/logging so CI logs reveal exactly what is written by Script 5 for faster diagnosis.

### Description
- Added `DATE_SOURCE_CANDIDATES` with common date column aliases and detect the real source column before export. 
- Normalize dates with `pd.to_datetime(..., errors="coerce")` and write a canonical `date` column with `YYYY-MM-DD`, dropping rows with unparseable dates and logging their count. 
- Hardened artifact writing by normalizing before writing, logging output path/columns/head and counts, and writing `local_matched_games_<AS_OF_DATE>.csv` plus a byte-identical `local_matched_games_latest.csv`. 
- Added post-write validation that reads the written file and raises clear `RuntimeError`s when the `date` column is missing, has zero valid rows, or contains any invalid dates.

### Testing
- Ran `python -m py_compile 2026/src/5_Isotonic_based_betting_strategy_2026.py` which succeeded with no syntax errors. 
- Inspected real artifacts with ad-hoc scripts and confirmed `2026/output/LightGBM/local_matched_games_2026-04-03.csv` was previously an empty export containing only the header `date,home_team,away_team,home_win_rate,prob_iso,prob_used,odds_1,EV_€_per_100,win,pnl,stake` while `local_matched_games_2026-01-17.csv` contained valid `YYYY-MM-DD` `date` rows. 
- Executing the script end-to-end (`python 2026/src/5_Isotonic_based_betting_strategy_2026.py`) now fails early with the new guardrail `RuntimeError: local_matched_games dated export has 0 valid date rows after normalization` on this dataset, which is expected behavior to avoid letting downstream validation fail silently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d146f9e83c8331a73f31897d227a28)