### PR TITLE
Restore cumulative ACC continuity and skip LOCAL search on insufficient history

### DIFF
--- a/2026/src/4_calculate_betting_statistics_2026.py
+++ b/2026/src/4_calculate_betting_statistics_2026.py
@@ -23,6 +23,7 @@ import os
 import numpy as np
 import logging
 from datetime import timedelta
+from pathlib import Path
 
 # Import shared utilities from the 2026 version
 from nba_utils_2026 import (
@@ -61,6 +62,8 @@ CANONICAL_BASE_COLUMNS = [
     "accuracy",
 ]
 
+ACC_PREFIX = "combined_nba_predictions_acc_"
+
 
 def normalize_column_name(col: str) -> str:
     """Normalize headers to canonical snake_case names."""
@@ -91,6 +94,64 @@ def normalize_prediction_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     ordered = CANONICAL_BASE_COLUMNS + LIVE_PROB_COLUMNS
     remaining = [c for c in out.columns if c not in ordered]
     return out[ordered + remaining]
+
+
+def build_game_key(df: pd.DataFrame) -> pd.Series:
+    """Build stable game key from date + home_team + away_team."""
+    work = df.copy()
+    date_source = "date" if "date" in work.columns else "game_date"
+    work["_game_date"] = pd.to_datetime(work.get(date_source), errors="coerce").dt.strftime("%Y-%m-%d")
+    return (
+        work["_game_date"].fillna("")
+        + "|"
+        + work.get("home_team", pd.Series(index=work.index, dtype=str)).astype(str).str.strip().str.upper()
+        + "|"
+        + work.get("away_team", pd.Series(index=work.index, dtype=str)).astype(str).str.strip().str.upper()
+    )
+
+
+def row_completeness_score(df: pd.DataFrame) -> pd.Series:
+    """Prefer more complete resolved rows during dedupe/upsert."""
+    score = pd.Series(0, index=df.index, dtype=float)
+    result_col = df.get("result", pd.Series(index=df.index, dtype=object))
+    score += result_col.notna() & ~result_col.astype(str).str.strip().isin(["", "0", "nan", "None"])
+    score += pd.to_numeric(df.get("accuracy"), errors="coerce").notna()
+    score += pd.to_numeric(df.get("home_team_prob"), errors="coerce").notna()
+    score += pd.to_numeric(df.get("odds_1"), errors="coerce").notna()
+    score += pd.to_numeric(df.get("odds_2"), errors="coerce").notna()
+    return score
+
+
+def upsert_by_game_key(base_df: pd.DataFrame, updates_df: pd.DataFrame) -> pd.DataFrame:
+    merged = pd.concat([base_df, updates_df], ignore_index=True)
+    merged = normalize_prediction_dataframe(merged)
+    merged["_game_key"] = build_game_key(merged)
+    merged["_score"] = row_completeness_score(merged)
+    merged["_date_sort"] = pd.to_datetime(merged["date"], errors="coerce")
+    merged = merged.sort_values(by=["_score", "_date_sort"], ascending=[False, False])
+    merged = merged.drop_duplicates(subset=["_game_key"], keep="first")
+    merged = merged.drop(columns=["_game_key", "_score", "_date_sort"], errors="ignore")
+    return normalize_prediction_dataframe(merged)
+
+
+def load_latest_previous_acc(prediction_dir: str, before_date: str) -> pd.DataFrame:
+    """Load latest previous cumulative ACC file strictly before `before_date`."""
+    cutoff = pd.to_datetime(before_date, errors="coerce")
+    candidates = []
+    for p in Path(prediction_dir).glob(f"{ACC_PREFIX}*.csv"):
+        date_part = p.stem.replace(ACC_PREFIX, "")
+        dt = pd.to_datetime(date_part, errors="coerce")
+        if pd.isna(dt) or dt >= cutoff:
+            continue
+        candidates.append((dt, p))
+
+    if not candidates:
+        logging.info("No previous ACC file found before %s in %s", before_date, prediction_dir)
+        return normalize_prediction_dataframe(pd.DataFrame())
+
+    _, latest_path = max(candidates, key=lambda x: x[0])
+    logging.info("Using previous cumulative ACC file: %s", latest_path)
+    return normalize_prediction_dataframe(pd.read_csv(latest_path))
 
 # Get current date information
 today, today_str, today_str_format = get_current_date()
@@ -171,19 +232,12 @@ def process_prediction_file(predict_file, last_prediction, prediction_dir):
             predict_df[col] = predict_df[col].astype(str).str.replace(',', '.').astype(float)
     predict_df = normalize_prediction_dataframe(predict_df)
 
-    # Path for combined data (one file per prediction date)
-    combined_file_path = os.path.join(prediction_dir, f'combined_nba_predictions_acc_{last_prediction}.csv')
-    # Load existing combined file or create new
-    try:
-        combined_df = pd.read_csv(combined_file_path)
-    except FileNotFoundError:
-        combined_df = pd.DataFrame()
-    combined_df = normalize_prediction_dataframe(combined_df)
+    # Start from latest previous cumulative ACC file, then upsert new prediction day rows.
+    combined_df = load_latest_previous_acc(prediction_dir, today_str_format)
 
-    # Append and sort by date descending
+    # Upsert and sort
     predict_df['accuracy'] = np.nan  # add placeholder column
-    combined_df = pd.concat([combined_df, predict_df], ignore_index=True)
-    combined_df = normalize_prediction_dataframe(combined_df)
+    combined_df = upsert_by_game_key(combined_df, predict_df)
     combined_df = combined_df.sort_values(by='date', ascending=False)
     # Display top rows for user
     logging.info("Combined predictions (latest 10 rows):\n%s", combined_df.head(10).to_string(index=False))
@@ -263,11 +317,28 @@ def update_betting_statistics(combined_df, most_recent_date, prediction_dir):
         subset=["date", "home_team", "away_team", "home_team_prob"],
         inplace=True,
     )
-    season_df = season_df.sort_values('date', ascending=False).drop_duplicates(
-        subset=['date', 'home_team', 'away_team'], keep='first'
-    )
+    previous_rows = int(len(combined_df))
+    updated_rows = season_df[pd.to_datetime(season_df["date"], errors="coerce") == pd.to_datetime(most_recent_date)].copy()
+    updated_rows = updated_rows[
+        (updated_rows["result"] == updated_rows["home_team"])
+        | (updated_rows["result"] == updated_rows["away_team"])
+    ]
+    season_df = upsert_by_game_key(normalize_prediction_dataframe(pd.DataFrame()), season_df)
+    season_df = season_df.sort_values('date', ascending=False)
     season_df = normalize_prediction_dataframe(season_df)
     season_df.to_csv(save_path, index=False)
+    played_rows = season_df[
+        (season_df["result"] == season_df["home_team"])
+        | (season_df["result"] == season_df["away_team"])
+    ].copy()
+    date_series = pd.to_datetime(season_df["date"], errors="coerce").dropna()
+    min_date = date_series.min().strftime("%Y-%m-%d") if not date_series.empty else "NA"
+    max_date = date_series.max().strftime("%Y-%m-%d") if not date_series.empty else "NA"
+    logging.info("Previous ACC rows: %d", previous_rows)
+    logging.info("Updated rows from latest resolved day: %d", int(len(updated_rows)))
+    logging.info("ACC rows after upsert: %d", int(len(season_df)))
+    logging.info("ACC played rows: %d", int(len(played_rows)))
+    logging.info("ACC date range: %s -> %s", min_date, max_date)
     logging.info(f"Updated betting statistics saved to {save_path}")
     return season_df
 

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -71,6 +71,7 @@ PROB_CLIP_HI = 0.80
 # IMPORTANT: dashboard window is last 200 played games
 LOCAL_SEARCH_N = 200
 FAIR_COMPARE_N = 200
+MIN_HIST_ROWS_FOR_LOCAL = 100
 
 START_BANKROLL = 1000.0
 
@@ -675,6 +676,10 @@ def run_self_test(df_all: pd.DataFrame, live_meta: dict | None = None) -> None:
         reduced = suspicious["prob_used"] <= 0.55
         if not reduced.any():
             raise AssertionError("Expected underdog/high-prob rows to cap/shrink prob_used")
+
+
+def classify_local_search_history(hist_rows: int, min_required: int = MIN_HIST_ROWS_FOR_LOCAL) -> str:
+    return "insufficient_history" if int(hist_rows) < int(min_required) else "ok"
 
 def evaluate_params_on_hist_window(
     hist_window: pd.DataFrame,
@@ -1646,16 +1651,31 @@ def main() -> None:
     # ------------------------------------------------------------------
     min_EV = MIN_EV_DEFAULT
     hist_window_200 = df_past_sorted.tail(int(FAIR_COMPARE_N)).copy()  # last 200 played games
+    hist_rows = int(len(df_past_sorted))
+    history_status = classify_local_search_history(hist_rows, MIN_HIST_ROWS_FOR_LOCAL)
+    insufficient_history = history_status == "insufficient_history"
 
-    local_params, _ = find_best_local_params_lastN(
-        df_past_sorted,
-        window_n=LOCAL_SEARCH_N,          # =200
-        flat_stake_backtest=FLAT_STAKE,
-        min_ev=min_EV,
-        prob_clip_lo=PROB_CLIP_LO,
-        prob_clip_hi=PROB_CLIP_HI,
-        min_trades_local=10,
-    )
+    if insufficient_history:
+        logging.warning(
+            "LOCAL search skipped_insufficient_history: hist_rows=%d min_required=%d",
+            hist_rows,
+            int(MIN_HIST_ROWS_FOR_LOCAL),
+        )
+        logging.warning(
+            "Preserving previous local_matched/strategy_params artifacts because historical input is insufficient."
+        )
+
+    local_params = None
+    if not insufficient_history:
+        local_params, _ = find_best_local_params_lastN(
+            df_past_sorted,
+            window_n=LOCAL_SEARCH_N,          # =200
+            flat_stake_backtest=FLAT_STAKE,
+            min_ev=min_EV,
+            prob_clip_lo=PROB_CLIP_LO,
+            prob_clip_hi=PROB_CLIP_HI,
+            min_trades_local=10,
+        )
 
     # fallback if search found nothing
     if not local_params:
@@ -1749,39 +1769,41 @@ def main() -> None:
         o = float(r[HOME_ODDS_COL])
         bankroll_last_200 += FLAT_STAKE * (p * (o - 1.0) - (1.0 - p))
 
-    # -------------------------
-    # Write the ONLY file you want to be correct on dashboard:
-    # web/public/data/local_matched_games_latest.csv
-    # -------------------------
-    write_latest_local_matched_csv(
-      df_past_sorted,
-      params_used=local_params,
-      target_dt=target_dt,
-      window_n=FAIR_COMPARE_N,   # 200
-      min_ev=min_EV,
-      stake=FLAT_STAKE,
-      prob_clip_lo=PROB_CLIP_LO,
-      prob_clip_hi=PROB_CLIP_HI,
-      historical_subset=historical_subset_for_export,
-    )
+    resolved_local_matched_date = as_of_date
+    if not insufficient_history:
+        # -------------------------
+        # Write the ONLY file you want to be correct on dashboard:
+        # web/public/data/local_matched_games_latest.csv
+        # -------------------------
+        write_latest_local_matched_csv(
+          df_past_sorted,
+          params_used=local_params,
+          target_dt=target_dt,
+          window_n=FAIR_COMPARE_N,   # 200
+          min_ev=min_EV,
+          stake=FLAT_STAKE,
+          prob_clip_lo=PROB_CLIP_LO,
+          prob_clip_hi=PROB_CLIP_HI,
+          historical_subset=historical_subset_for_export,
+        )
 
-    resolved_local_matched_date = write_local_matched_artifacts(
-        matched_export_latest,
-        as_of_date=as_of_date,
-        output_dir=out_dir,
-        params_used=local_params,
-        source_name=local_matched_export_source,
-        allow_header_only=bool(matched_export_latest.empty),
-        intentional_empty=bool(matched_export_latest.empty),
-    )
+        resolved_local_matched_date = write_local_matched_artifacts(
+            matched_export_latest,
+            as_of_date=as_of_date,
+            output_dir=out_dir,
+            params_used=local_params,
+            source_name=local_matched_export_source,
+            allow_header_only=bool(matched_export_latest.empty),
+            intentional_empty=bool(matched_export_latest.empty),
+        )
 
-    # Also write strategy params TXT (generated each run)
-    write_strategy_params(local_params, min_ev=min_EV, as_of_date=as_of_date, stake=FLAT_STAKE, output_dir=out_dir)
-    validate_dated_dashboard_artifacts(
-        output_dir=out_dir,
-        as_of_date=as_of_date,
-        local_matched_date=resolved_local_matched_date,
-    )
+        # Also write strategy params TXT (generated each run)
+        write_strategy_params(local_params, min_ev=min_EV, as_of_date=as_of_date, stake=FLAT_STAKE, output_dir=out_dir)
+        validate_dated_dashboard_artifacts(
+            output_dir=out_dir,
+            as_of_date=as_of_date,
+            local_matched_date=resolved_local_matched_date,
+        )
 
     # Minimal snapshot for trace (keep structure, but based on LOCAL params + last-200)
     snapshot = {
@@ -1792,6 +1814,7 @@ def main() -> None:
             "params_source": params_source,
             "combined_file_path": str(combined_source_path),
             "local_matched_games_source": local_matched_export_source,
+            "local_search_status": "skipped_insufficient_history" if insufficient_history else "ran",
         },
         "params_used_type": "LOCAL",
         "params_used": local_params,
@@ -1821,7 +1844,8 @@ def main() -> None:
         "strategy_variant_label": strategy_variant_label,
         "params_source": params_source,
         "combined_file_path": str(combined_source_path),
-        "local_matched_games_latest_written": True,
+        "local_matched_games_latest_written": (not insufficient_history),
+        "local_search_status": "skipped_insufficient_history" if insufficient_history else "ran",
         "local_window_games": int(len(hist_window_200)),
         "local_matched_games": int(len(matched_export_latest)),
         "prob_col_hist": PROB_COL_HIST,
@@ -1829,12 +1853,13 @@ def main() -> None:
     })
 
     run_self_test(df_all, live_meta=live_meta)
-    logging.info("DONE. local_matched_games_latest.csv updated using LOCAL params on last-200 window ending %s.", as_of_date)
-
-    p = find_repo_root() / "web" / "public" / "data" / "local_matched_games_latest.csv"
-
-    logging.info("AFTER WRITE: latest size=%d bytes mtime=%s", p.stat().st_size, datetime.fromtimestamp(p.stat().st_mtime))
-    logging.info("AFTER WRITE HEAD:\n%s", "\n".join(p.read_text(encoding="utf-8").splitlines()[:5]))
+    if insufficient_history:
+        logging.info("DONE. LOCAL search skipped due to insufficient history; prior local artifacts preserved.")
+    else:
+        logging.info("DONE. local_matched_games_latest.csv updated using LOCAL params on last-200 window ending %s.", as_of_date)
+        p = find_repo_root() / "web" / "public" / "data" / "local_matched_games_latest.csv"
+        logging.info("AFTER WRITE: latest size=%d bytes mtime=%s", p.stat().st_size, datetime.fromtimestamp(p.stat().st_mtime))
+        logging.info("AFTER WRITE HEAD:\n%s", "\n".join(p.read_text(encoding="utf-8").splitlines()[:5]))
 
        
 if __name__ == "__main__":

--- a/2026/tests/test_cumulative_acc_and_local_guard.py
+++ b/2026/tests/test_cumulative_acc_and_local_guard.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import numpy as np
+import pandas as pd
+
+
+def _load_module(module_name: str, rel_path: str):
+    base = Path(__file__).resolve().parents[1]
+    mod_path = base / "src" / rel_path
+    spec = importlib.util.spec_from_file_location(module_name, mod_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+script4 = _load_module("script4_2026", "4_calculate_betting_statistics_2026.py")
+script5 = _load_module("script5_2026", "5_Isotonic_based_betting_strategy_2026.py")
+
+
+def test_script4_upsert_preserves_history_and_prefers_resolved_rows():
+    base = pd.DataFrame(
+        {
+            "date": ["2026-01-01", "2026-01-02"],
+            "home_team": ["BOS", "NYK"],
+            "away_team": ["LAL", "MIA"],
+            "home_team_prob": [0.62, 0.51],
+            "odds_1": [1.7, 1.9],
+            "odds_2": [2.2, 1.95],
+            "result": [np.nan, np.nan],
+            "accuracy": [np.nan, np.nan],
+        }
+    )
+    updates = pd.DataFrame(
+        {
+            "date": ["2026-01-02", "2026-01-03"],
+            "home_team": ["NYK", "DEN"],
+            "away_team": ["MIA", "PHX"],
+            "home_team_prob": [0.51, 0.57],
+            "odds_1": [1.9, 1.8],
+            "odds_2": [1.95, 2.0],
+            "result": ["NYK", np.nan],
+            "accuracy": [1.0, np.nan],
+        }
+    )
+
+    merged = script4.upsert_by_game_key(base, updates)
+
+    assert len(merged) == 3
+    row = merged[(merged["date"] == "2026-01-02") & (merged["home_team"] == "NYK")].iloc[0]
+    assert row["result"] == "NYK"
+    assert float(row["accuracy"]) == 1.0
+
+
+def test_script5_classifies_insufficient_history_for_local_search():
+    assert script5.classify_local_search_history(99, 100) == "insufficient_history"
+    assert script5.classify_local_search_history(100, 100) == "ok"


### PR DESCRIPTION
### Motivation
- Script 5 was receiving a trivially small historical sample because Script 4 rebuilt `combined_nba_predictions_acc_<today>.csv` from only the last resolved day instead of preserving cumulative season history, breaking LOCAL parameter search and producing header-only exports.
- The goal is to minimally fix Script 4 to preserve cumulative ACC history and to add a small-history guard in Script 5 so LOCAL search is skipped (and prior artifacts preserved) when historical data is insufficient.

### Description
- In `2026/src/4_calculate_betting_statistics_2026.py` added helpers `build_game_key`, `row_completeness_score`, `upsert_by_game_key`, and `load_latest_previous_acc` and changed the prediction processing flow to load the latest prior cumulative ACC file and upsert new rows by game key with dedupe that prefers more complete/resolved rows.
- Script 4 now logs cumulative diagnostics including `Previous ACC rows`, `Updated rows from latest resolved day`, `ACC rows after upsert`, `ACC played rows`, and `ACC date range` before writing `combined_nba_predictions_acc_<today>.csv` to confirm continuity.
- In `2026/src/5_Isotonic_based_betting_strategy_2026.py` added `MIN_HIST_ROWS_FOR_LOCAL = 100`, `classify_local_search_history(...)`, and a guarded path that detects insufficient historical played rows, logs a `skipped_insufficient_history` reason, and preserves previous `local_matched` and strategy param artifacts instead of overwriting them; genuine-empty exports for valid-history runs are preserved unchanged.
- Added regression tests `2026/tests/test_cumulative_acc_and_local_guard.py` that verify the upsert preserves history and prefers resolved rows and that history classification works for the threshold.

### Testing
- Ran unit tests: `pytest -q 2026/tests/test_cumulative_acc_and_local_guard.py 2026/tests/test_live_safety.py` and observed all tests passing (`4 passed`).
- The new tests exercise `upsert_by_game_key` and `classify_local_search_history` behavior and passed alongside the existing live safety tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d167c421f0833190cac649f3171598)