### PR TITLE
Make dated metrics snapshots truthful and expose canonical bet-log in dashboard state

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -1645,6 +1645,21 @@ def main() -> None:
     logging.info("Refreshed ACC combined with calibrated probabilities -> %s", acc_path)
 
     combined_source_path = iso_path if strategy_variant == "iso" else combined_path
+    snapshot_combined_source_path = combined_source_path
+    if as_of_date != target_ymd:
+        snapshot_path = (
+            kelly_dir / f"combined_nba_predictions_iso_{as_of_date}.csv"
+            if strategy_variant == "iso"
+            else Path(pred_dir) / f"combined_nba_predictions_acc_{as_of_date}.csv"
+        )
+        if not snapshot_path.exists():
+            df_all.to_csv(snapshot_path, index=False, encoding="utf-8")
+            logging.info(
+                "Wrote as-of aligned combined snapshot for metrics date %s -> %s",
+                as_of_date,
+                snapshot_path,
+            )
+        snapshot_combined_source_path = snapshot_path
 
     # ------------------------------------------------------------------
     # CORE: generate LOCAL params from LAST 200 played games (dashboard)
@@ -1813,19 +1828,22 @@ def main() -> None:
 
     snapshot = {
         "meta": {
+            "as_of_date": as_of_date,
             "eval_base_date_max": as_of_date,
             "strategy_variant": strategy_variant,
             "strategy_variant_label": strategy_variant_label,
             "params_source": params_source,
-            "combined_file_path": str(combined_source_path),
+            "combined_file_path": str(snapshot_combined_source_path),
             "local_matched_games_source": local_matched_export_source,
             "local_search_status": local_search_status,
         },
+        "as_of_date": as_of_date,
         "params_used_type": params_used_type,
         "fallback_used": fallback_used,
         "fallback_reason": fallback_reason,
         "local_search_status": local_search_status,
         "params_source": params_source,
+        "params_source_type": params_used_type,
         "params_used": local_params,
         "local_window_200": {
             "min_EV_applied": float(min_EV),
@@ -1855,8 +1873,11 @@ def main() -> None:
         "strategy_variant": strategy_variant,
         "strategy_variant_label": strategy_variant_label,
         "params_source": params_source,
-        "combined_file_path": str(combined_source_path),
+        "combined_file_path": str(snapshot_combined_source_path),
         "local_matched_games_latest_written": (not insufficient_history),
+        "params_used_type": params_used_type,
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
         "local_search_status": "skipped_insufficient_history" if insufficient_history else "ran",
         "local_window_games": int(len(hist_window_200)),
         "local_matched_games": int(len(matched_export_latest)),

--- a/scripts/build_dashboard_assets.js
+++ b/scripts/build_dashboard_assets.js
@@ -391,6 +391,7 @@ function main() {
   const sourceFallbackReason = metricsSnapshot?.fallback_reason || strategyParams?.fallback_reason || null;
   const asOfDate =
     strategyParams.as_of_date ||
+    metricsSnapshot?.as_of_date ||
     metricsSnapshot?.meta?.eval_base_date_max ||
     paramsSource.artifactDate ||
     selectedSnapshotDate ||
@@ -474,13 +475,17 @@ function main() {
   // ----------------------------
   const minEV = (strategyParams.min_ev !== undefined) ? strategyParams.min_ev : paramsUsed.min_EV;
 
-  const activeFiltersText = [
+  const activeFiltersParts = [
     `HW \u2265 ${formatNumber(paramsUsed.home_win_rate_threshold, 2)}`,
     `odds ${formatNumber(paramsUsed.odds_min, 2)}\u2013${formatNumber(paramsUsed.odds_max, 2)}`,
     `p \u2265 ${formatNumber(paramsUsed.prob_threshold, 2)}`,
     `EV > ${formatMinEv(minEV)}`,
     `window ${REQUIRED_WINDOW_SIZE} games (${windowStart} \u2192 ${windowEnd})`,
-  ].join(' | ');
+  ];
+  if (sourceFallbackUsed) {
+    activeFiltersParts.push(`fallback (${sourceFallbackReason || 'safe_fallback_used'})`);
+  }
+  const activeFiltersText = activeFiltersParts.join(' | ');
 
   // ----------------------------
   // Windowed local matches count
@@ -511,8 +516,10 @@ function main() {
     window_start: windowStart,
     window_end: windowEnd,
     active_filters_text: activeFiltersText,
+    snapshot_date_selected: selectedSnapshotDate,
     params_used_label: 'Historical',
     params_source_label: metricsSnapshot?.params_used_type || (paramsSource.sourceType === 'default' ? 'default' : 'strategy_params'),
+    params_used: paramsUsed,
     effective_params: {
       as_of_date: asOfDate,
       window_size: REQUIRED_WINDOW_SIZE,
@@ -546,6 +553,8 @@ function main() {
         : null,
     },
     strategy_as_of_date: strategyAsOfDate,
+    bet_log_source_file: selectedBetLogPath ? path.relative(repoRoot, selectedBetLogPath) : null,
+    bet_log_latest_date_in_file: betLogLatestDateInFile,
     last_update_utc: new Date().toISOString(),
     source_files: {
       combined: 'combined_latest.csv',
@@ -553,8 +562,6 @@ function main() {
       local_matched: 'local_matched_games_latest.csv',
       local_matched_source: path.relative(repoRoot, localMatchedSourcePath),
       bet_log: selectedBetLogPath ? 'bet_log_flat_live.csv' : null,
-      bet_log_source_file: selectedBetLogPath ? path.relative(repoRoot, selectedBetLogPath) : null,
-      bet_log_latest_date_in_file: betLogLatestDateInFile,
       bet_log_freshness_warning: betLogFreshnessWarning,
     },
     strategy_matches_window: inWindowLocalMatches.length,
@@ -631,6 +638,25 @@ function main() {
   }
   if (!dashboardState.fallback_used && dashboardState.fallback_reason) {
     throw new Error('Snapshot consistency check failed: fallback_reason set while fallback_used=false.');
+  }
+  if (
+    paramsSource.sourceType === 'metrics_snapshot_dated' &&
+    paramsSource.artifactDate &&
+    paramsSource.artifactDate !== selectedSnapshotDate
+  ) {
+    console.warn(
+      `Snapshot selection warning: selected snapshot ${selectedSnapshotDate} resolved to dated metrics artifact ${paramsSource.artifactDate}.`
+    );
+  }
+  if (
+    metricsSnapshot?.meta?.eval_base_date_max &&
+    paramsSource.artifactDate &&
+    metricsSnapshot.meta.eval_base_date_max !== paramsSource.artifactDate
+  ) {
+    throw new Error(
+      `Snapshot consistency check failed: metrics meta eval_base_date_max (${metricsSnapshot.meta.eval_base_date_max}) ` +
+      `!= artifact date (${paramsSource.artifactDate}).`
+    );
   }
 
   // Sanity output

--- a/scripts/script5_export_outputs.py
+++ b/scripts/script5_export_outputs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from datetime import date
 from pathlib import Path
 
@@ -24,6 +25,11 @@ REQUIRED_COLUMNS = [
 ]
 
 STRATEGY_VARIANTS = {"acc", "iso"}
+
+
+def extract_date_from_filename(name: str) -> str | None:
+    match = re.search(r"(\d{4}-\d{2}-\d{2})", str(name))
+    return match.group(1) if match else None
 
 
 def resolve_source_root(base_dir: Path) -> Path:
@@ -270,6 +276,7 @@ def build_metrics_snapshot(
 
     return {
         "meta": {
+            "as_of_date": as_of_date,
             "eval_base_date_max": as_of_date,
             "strategy_results_label": "Simulated (last 200 games window)",
             "live_bets_label": "Live bets (2026 YTD, unfiltered)",
@@ -286,11 +293,13 @@ def build_metrics_snapshot(
             "real_bets_note": real_bets_note,
             "local_search_status": local_search_status,
         },
+        "as_of_date": as_of_date,
         "params_used_type": params_used_type,
         "fallback_used": fallback_used,
         "fallback_reason": fallback_reason,
         "local_search_status": local_search_status,
         "params_source": params_source,
+        "params_source_type": params_used_type,
         "params_used": params,
         "realized": {
             "count": realized_count,
@@ -414,6 +423,14 @@ def main() -> int:
     else:
         real_bets_note = "available"
 
+    snapshot_combined_path = combined_path
+    if combined_path is not None:
+        combined_date = extract_date_from_filename(combined_path.name)
+        if combined_date and combined_date != as_of_date:
+            dated_candidate = combined_path.parent / combined_path.name.replace(combined_date, as_of_date, 1)
+            if dated_candidate.exists():
+                snapshot_combined_path = dated_candidate
+
     snapshot = build_metrics_snapshot(
         export_df,
         as_of_date=as_of_date,
@@ -423,7 +440,7 @@ def main() -> int:
         strategy_variant=strategy_variant,
         strategy_variant_label=strategy_variant_label,
         params_source=params_source,
-        combined_file_path=str(combined_path) if combined_path else None,
+        combined_file_path=str(snapshot_combined_path) if snapshot_combined_path else None,
         local_matched_games_source=str(local_matched_path) if local_matched_path else None,
         real_bets_available=real_bets_available,
         real_bets_note=real_bets_note,
@@ -456,7 +473,7 @@ def main() -> int:
         "strategy_variant": strategy_variant,
         "strategy_variant_label": strategy_variant_label,
         "params_source": params_source,
-        "combined_file_path": str(combined_path) if combined_path else None,
+        "combined_file_path": str(snapshot_combined_path) if snapshot_combined_path else None,
         "local_matched_games_source": str(local_matched_path) if local_matched_path else None,
         "real_bets_available": real_bets_available,
         "real_bets_note": real_bets_note,

--- a/web/public/data/dashboard_state.json
+++ b/web/public/data/dashboard_state.json
@@ -3,9 +3,19 @@
   "window_size": 200,
   "window_start": "2026-04-03",
   "window_end": "2026-04-03",
-  "active_filters_text": "HW ≥ 0.50 | odds 2.30–3.20 | p ≥ 0.45 | EV > — | window 200 games (2026-04-03 → 2026-04-03)",
+  "active_filters_text": "HW ≥ 0.50 | odds 2.30–3.20 | p ≥ 0.45 | EV > — | window 200 games (2026-04-03 → 2026-04-03) | fallback (skipped_insufficient_history)",
+  "snapshot_date_selected": "2026-04-03",
   "params_used_label": "Historical",
   "params_source_label": "fallback",
+  "params_used": {
+    "home_win_rate_threshold": 0.5,
+    "odds_min": 2.3,
+    "odds_max": 3.2,
+    "prob_threshold": 0.45,
+    "n_trades": 0,
+    "profit_€": 0,
+    "roi_%": 0
+  },
   "effective_params": {
     "as_of_date": "2026-04-03",
     "window_size": 200,
@@ -30,15 +40,15 @@
     "strategy_params_txt": null
   },
   "strategy_as_of_date": null,
-  "last_update_utc": "2026-04-04T21:21:05.818Z",
+  "bet_log_source_file": "2026/bet_log/bet_log_flat_live.csv",
+  "bet_log_latest_date_in_file": "2026-03-14",
+  "last_update_utc": "2026-04-04T22:01:55.569Z",
   "source_files": {
     "combined": "combined_latest.csv",
     "combined_source": "Kelly/combined_nba_predictions_iso_2026-04-04.csv",
     "local_matched": "local_matched_games_latest.csv",
     "local_matched_source": "web/public/data/local_matched_games_latest.csv",
     "bet_log": "bet_log_flat_live.csv",
-    "bet_log_source_file": "2026/bet_log/bet_log_flat_live.csv",
-    "bet_log_latest_date_in_file": "2026-03-14",
     "bet_log_freshness_warning": null
   },
   "strategy_matches_window": 0


### PR DESCRIPTION
### Motivation
- The dated `metrics_snapshot_<date>.json` artifacts were emitting fallback-like params while claiming `params_used_type=LOCAL` and referencing combined files with a different date, causing GitHub dashboard to misrepresent local semantics.
- The dashboard also needed a clear canonical bet-log choice and visible metadata so fresher bet-log candidates are not silently ignored.

### Description
- Update snapshot generation in `2026/src/5_Isotonic_based_betting_strategy_2026.py` to include explicit `as_of_date`, `params_used_type`, `fallback_used`, `fallback_reason`, `params_source_type`, and to reference/write an as-of-aligned `combined_*` file when the computed `as_of_date` differs from the run `target_ymd` so `combined_file_path` always matches the snapshot date.
- Apply the same as-of/combined alignment and add `as_of_date`/fallback metadata in `scripts/script5_export_outputs.py` (including helper `extract_date_from_filename`) so `metrics_snapshot.json` and `metrics_snapshot_<date>.json` are truthful and self-consistent.
- Make the dashboard generator `scripts/build_dashboard_assets.js` keep dated `metrics_snapshot_<date>.json` as the canonical filter source but surface fallback status explicitly in `active_filters_text`, add `snapshot_date_selected`, `params_used`, `bet_log_source_file`, and `bet_log_latest_date_in_file` into `dashboard_state.json`, and add consistency checks that `metrics_snapshot.meta.eval_base_date_max` matches the artifact date.
- Preserve canonical bet-log selection behavior (prefer `2026/bet_log/bet_log_flat_live.csv` when present), report freshness warnings if another candidate is newer, and copy the selected bet-log into `web/public/data/bet_log_flat_live.csv` so the dashboard uses the freshest canonical source.

### Testing
- Ran Python static checks with `python -m py_compile 2026/src/5_Isotonic_based_betting_strategy_2026.py scripts/script5_export_outputs.py` and it completed without errors.
- Ran Node syntax check `node --check scripts/build_dashboard_assets.js` and it completed without errors.
- Executed the dashboard asset build `node scripts/build_dashboard_assets.js` to generate `web/public/data` and observed successful output and warnings where applicable (dashboard state now records `bet_log_latest_date_in_file` as `2026-03-14`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d189cc3b988331b8a86a9cab796493)