### PR TITLE
Add walk-forward stability gating, no-bet fallback, and proxy robustness; refine home-win handling

### DIFF
--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -72,6 +72,23 @@ PROB_CLIP_HI = 0.80
 LOCAL_SEARCH_N = 200
 FAIR_COMPARE_N = 200
 MIN_HIST_ROWS_FOR_LOCAL = 100
+LOCAL_TAIL_LADDER = [300, 400, 500]
+WALK_TRAIN_MIN_DAYS = 21
+WALK_TEST_DAYS = 21
+WALK_STEP_DAYS = 7
+MIN_WALK_SPLITS = 4
+MIN_TEST_TRADES_TOTAL = 50
+MIN_ACTIVE_SPLITS = 3
+MIN_TRADES_PER_ACTIVE_SPLIT = 5
+MIN_TRADES_TRAIN = 20
+MIN_TRADES_PER_WINDOW = 25
+N_WINDOWS = [300, 400, 500]
+STABILITY_HITS_NEEDED = 2
+USE_SOFT_GATE = True
+SOFT_Q = 0.20
+MIN_Q_TRADES = 4
+SCORE_MODE = "lcb_roi"
+LCB_K = 0.5
 
 START_BANKROLL = 1000.0
 
@@ -571,16 +588,18 @@ def compute_home_win_rates(df_all: pd.DataFrame, ymd: str, pred_dir: str) -> str
     df = df_all.copy()
     df = _ensure_datetime(df, DATE_COL)
     df["date"] = df[DATE_COL]
+    played_mask = df.get(RESULT_COL, pd.Series(index=df.index, dtype=float)).notna()
+    played_home = df.loc[played_mask].copy()
+    played_home = played_home[played_home["home_team"].notna()].sort_values("date")
 
     team_results = {}
     for team in df["home_team"].dropna().unique():
-        team_games = df[(df["home_team"] == team) | (df["away_team"] == team)].sort_values("date", ascending=False).head(20)
-        home_games = team_games[team_games["home_team"] == team]
-        total_home = len(home_games)
-        home_wins = len(home_games[home_games.get("result", pd.Series(index=home_games.index)).astype(str) == str(team)])
-        hwr = round(home_wins / total_home, 2) if total_home > 0 else 0.0
+        team_home_games = played_home[played_home["home_team"] == team].tail(20)
+        total_home = int(len(team_home_games))
+        home_wins = int(pd.to_numeric(team_home_games.get(RESULT_COL), errors="coerce").fillna(0).astype(int).sum()) if total_home else 0
+        hwr = round(home_wins / total_home, 4) if total_home > 0 else np.nan
         team_results[team] = {
-            "Total Last 20 Games": len(team_games),
+            "Total Last 20 Home Games": total_home,
             "Total Home Games": total_home,
             "Home Wins": home_wins,
             "Home Win Rate": hwr,
@@ -596,7 +615,7 @@ def compute_home_win_rates(df_all: pd.DataFrame, ymd: str, pred_dir: str) -> str
 def attach_home_win_rate(df: pd.DataFrame, hwr_path: str) -> pd.DataFrame:
     if not os.path.exists(hwr_path):
         logging.warning("Home win rate file missing: %s", hwr_path)
-        df[HOMEWR_COL] = 0.0
+        df[HOMEWR_COL] = np.nan
         return df
 
     base_df = df.drop(columns=[HOMEWR_COL], errors="ignore").copy()
@@ -622,7 +641,7 @@ def attach_home_win_rate(df: pd.DataFrame, hwr_path: str) -> pd.DataFrame:
     out = base_df.merge(hwr_m, left_on="_home_team_norm", right_on="_team_norm", how="left")
 
     out.rename(columns={win_col: HOMEWR_COL}, inplace=True)
-    out[HOMEWR_COL] = pd.to_numeric(out[HOMEWR_COL], errors="coerce").fillna(0.0)
+    out[HOMEWR_COL] = pd.to_numeric(out[HOMEWR_COL], errors="coerce")
 
     out.drop(columns=["_team_norm", "_home_team_norm"], inplace=True, errors="ignore")
     return out
@@ -814,7 +833,7 @@ def find_best_local_params_lastN(
     min_ev: float,
     prob_clip_lo: float,
     prob_clip_hi: float,
-    min_trades_local: int = 10,
+    min_trades_local: int = 1,
 ) -> Tuple[Optional[dict], Optional[pd.DataFrame]]:
     if hist_df is None or hist_df.empty:
         return None, None
@@ -847,7 +866,7 @@ def find_best_local_params_lastN(
                         (df["EV_€_per_100"] > float(min_ev))
                     )
                     sub = df.loc[mask].copy()
-                    if sub.empty or len(sub) < min_trades_local:
+                    if sub.empty or len(sub) < int(min_trades_local):
                         continue
 
                     sub["pnl"] = np.where(
@@ -865,6 +884,8 @@ def find_best_local_params_lastN(
                             "odds_max": round(float(o_max), 2),
                             "prob_threshold": round(float(pmin), 2),
                             "n_trades": int(len(sub)),
+                            "win_rate_%": round(float(sub[RESULT_COL].mean() * 100.0), 2),
+                            "avg_EV_€_per_100": round(float(sub["EV_€_per_100"].mean()), 2),
                             "profit_€": round(profit, 2),
                             "roi_%": round(profit / (len(sub) * flat_stake_backtest) * 100.0, 2),
                         }
@@ -930,32 +951,65 @@ def find_best_local_params_walk_forward(
     prob_clip_lo: float,
     prob_clip_hi: float,
     n_splits: int = 4,
-    min_trades_test_split: int = 10,
+    min_trades_test_split: int = MIN_TRADES_PER_ACTIVE_SPLIT,
 ):
     if hist_df is None or hist_df.empty:
         return None
 
     df = _ensure_datetime(hist_df, DATE_COL).sort_values(DATE_COL).tail(int(tail_n)).copy()
+    if {"home_team", "away_team"}.issubset(df.columns):
+        date_part = df[DATE_COL].dt.strftime("%Y-%m-%d").fillna("")
+        df["_game_key"] = (
+            date_part
+            + "_"
+            + df["home_team"].astype(str).str.strip().str.upper()
+            + "_"
+            + df["away_team"].astype(str).str.strip().str.upper()
+        )
+        df = df.drop_duplicates(subset=["_game_key"], keep="last")
+        df = df.drop(columns=["_game_key"], errors="ignore")
     df = _compute_prob_used(df, lo=prob_clip_lo, hi=prob_clip_hi, src=PROB_COL_HIST, dst="prob_used")
     df = _compute_ev_per_100(df, prob_col="prob_used", odds_col=HOME_ODDS_COL, dst="EV_€_per_100")
     df = df.dropna(subset=[HOMEWR_COL, "prob_used", HOME_ODDS_COL, RESULT_COL, "EV_€_per_100"]).copy()
-    if len(df) < max(80, n_splits * 20):
+    if len(df) < max(80, n_splits * MIN_TRADES_TRAIN):
         return None
 
-    fold_size = len(df) // n_splits
-    if fold_size <= 0:
+    min_date = df[DATE_COL].min()
+    max_date = df[DATE_COL].max()
+    if pd.isna(min_date) or pd.isna(max_date):
+        return None
+
+    split_starts = []
+    cursor = min_date + pd.Timedelta(days=WALK_TRAIN_MIN_DAYS)
+    while cursor + pd.Timedelta(days=WALK_TEST_DAYS) <= max_date + pd.Timedelta(days=1):
+        split_starts.append(cursor)
+        cursor += pd.Timedelta(days=WALK_STEP_DAYS)
+    if len(split_starts) < int(MIN_WALK_SPLITS):
         return None
 
     best = None
     for params in _iter_param_grid(prob_clip_lo):
-        test_rois = []
+        split_scores = []
         test_trades = []
         wf_test_profit_total = 0.0
+        split_count = 0
 
-        for split_idx in range(n_splits):
-            start = split_idx * fold_size
-            end = len(df) if split_idx == n_splits - 1 else (split_idx + 1) * fold_size
-            test_df = df.iloc[start:end]
+        for split_start in split_starts:
+            train_start = split_start - pd.Timedelta(days=WALK_TRAIN_MIN_DAYS)
+            train_df = df[(df[DATE_COL] >= train_start) & (df[DATE_COL] < split_start)]
+            test_df = df[(df[DATE_COL] >= split_start) & (df[DATE_COL] < split_start + pd.Timedelta(days=WALK_TEST_DAYS))]
+            split_count += 1
+            train_trades, _, _ = _evaluate_params_on_subset(
+                train_df,
+                params,
+                min_ev=min_ev,
+                stake=stake,
+                prob_clip_lo=prob_clip_lo,
+            )
+            if train_trades < int(MIN_TRADES_TRAIN):
+                test_trades.append(0)
+                split_scores.append(float("-inf"))
+                continue
             trades, profit, roi = _evaluate_params_on_subset(
                 test_df,
                 params,
@@ -963,13 +1017,16 @@ def find_best_local_params_walk_forward(
                 stake=stake,
                 prob_clip_lo=prob_clip_lo,
             )
-            test_rois.append(float(roi))
             test_trades.append(int(trades))
             wf_test_profit_total += float(profit)
+            split_scores.append(float(roi))
 
-        active_splits = int(sum(t >= min_trades_test_split for t in test_trades))
+        active_splits = int(sum(t >= int(min_trades_test_split) for t in test_trades))
         total_test_trades = int(sum(test_trades))
-        q20_trades = float(np.quantile(test_trades, 0.2)) if test_trades else 0.0
+        q20_trades = float(np.quantile(test_trades, SOFT_Q)) if test_trades else 0.0
+        finite_scores = [s for s in split_scores if np.isfinite(s)]
+        if not finite_scores:
+            continue
 
         full_trades, full_profit, full_roi = _evaluate_params_on_subset(
             df,
@@ -979,16 +1036,39 @@ def find_best_local_params_walk_forward(
             prob_clip_lo=prob_clip_lo,
         )
 
-        mean_roi = float(np.mean(test_rois)) if test_rois else 0.0
-        std_roi = float(np.std(test_rois)) if test_rois else 0.0
-        score = mean_roi - 0.5 * std_roi
+        mean_score = float(np.mean(finite_scores))
+        std_score = float(np.std(finite_scores))
+        lcb_score = mean_score - float(LCB_K) * std_score
+        mean_ev = float(df.loc[df[RESULT_COL].notna(), "EV_€_per_100"].mean()) if "EV_€_per_100" in df.columns else 0.0
+
+        if SCORE_MODE == "wf_profit":
+            score_value = float(wf_test_profit_total)
+        elif SCORE_MODE == "lcb_profit":
+            score_value = float(wf_test_profit_total) - float(LCB_K) * std_score
+        elif SCORE_MODE == "lcb_ev":
+            score_value = float(mean_ev) - float(LCB_K) * std_score
+        else:
+            score_value = float(lcb_score)
+
+        coverage_pass = (
+            split_count >= int(MIN_WALK_SPLITS)
+            and total_test_trades >= int(MIN_TEST_TRADES_TOTAL)
+            and active_splits >= int(MIN_ACTIVE_SPLITS)
+            and (
+                (not USE_SOFT_GATE)
+                or q20_trades >= float(MIN_Q_TRADES)
+            )
+        )
+        if not coverage_pass:
+            continue
 
         candidate = {
-            "score_mode": "lcb_roi",
-            "score": float(score),
+            "score_mode": SCORE_MODE,
+            "score": float(score_value),
+            "score_value": float(score_value),
             "params": params,
             "tail_n": int(tail_n),
-            "splits_used": int(n_splits),
+            "splits_used": int(split_count),
             "test_trades_total": int(total_test_trades),
             "active_splits": int(active_splits),
             "q20_trades": float(q20_trades),
@@ -1963,6 +2043,9 @@ def main() -> None:
         )
 
     local_params = None
+    no_bet_mode = False
+    used_global_fallback = False
+    used_safe_fallback = False
     local_tail_used = None
     local_ladder_attempts = []
     global_params = None
@@ -1974,11 +2057,12 @@ def main() -> None:
             min_ev=min_EV,
             prob_clip_lo=PROB_CLIP_LO,
             prob_clip_hi=PROB_CLIP_HI,
-            min_trades_local=10,
+            min_trades_local=1,
         )
 
         logging.info("=== [ROBUST++++] LOCAL PARAMS (WALK-FORWARD on FULL hist_df, coverage gate) ===")
-        for tail_n in (300, 400, 500):
+        best_local_wf = None
+        for tail_n in LOCAL_TAIL_LADDER:
             if len(df_past_sorted) < tail_n:
                 local_ladder_attempts.append(
                     f"  tail={tail_n} | rows={len(df_past_sorted)} | gate_pass=False | reason=insufficient_rows"
@@ -1991,20 +2075,27 @@ def main() -> None:
                 stake=FLAT_STAKE,
                 prob_clip_lo=PROB_CLIP_LO,
                 prob_clip_hi=PROB_CLIP_HI,
-                n_splits=4,
-                min_trades_test_split=10,
+                n_splits=MIN_WALK_SPLITS,
+                min_trades_test_split=MIN_TRADES_PER_ACTIVE_SPLIT,
             )
             if wf is None:
                 local_ladder_attempts.append(
                     f"  tail={tail_n} | rows={tail_n} | gate_pass=False | reason=walk_forward_unavailable"
                 )
                 continue
-            gate_pass = bool(wf["active_splits"] >= 2 and wf["q20_trades"] >= 10.0 and wf["test_trades_total"] >= 25)
-            if gate_pass and local_params is None:
+            gate_pass = bool(
+                wf["splits_used"] >= MIN_WALK_SPLITS
+                and wf["test_trades_total"] >= MIN_TEST_TRADES_TOTAL
+                and wf["active_splits"] >= MIN_ACTIVE_SPLITS
+                and (not USE_SOFT_GATE or wf["q20_trades"] >= MIN_Q_TRADES)
+            )
+            if gate_pass and (best_local_wf is None or float(wf["score_value"]) > float(best_local_wf["score_value"])):
+                best_local_wf = wf
                 local_params = dict(wf["params"])
+                local_params["score_value"] = float(wf["score_value"])
                 local_tail_used = int(tail_n)
                 logging.info("score_mode             : %s", wf["score_mode"])
-                logging.info("LCB(mean_test_ROI - 0.5*std): %.2f", float(wf["score"]))
+                logging.info("Local score value      : %.2f", float(wf["score_value"]))
                 logging.info("params: %s", wf["params"])
                 logging.info("LOCAL tail used        : %d", int(tail_n))
                 logging.info(
@@ -2038,71 +2129,91 @@ def main() -> None:
         for line in local_ladder_attempts:
             logging.info(line)
 
-        if local_params and global_params:
-            windows = [300, 400, 500]
-            min_trades_per_window = 25
-            hits_needed = 2
+        if local_params or global_params:
             local_eval = evaluate_strategy_stability(
                 df_past_sorted,
                 local_params,
-                windows=windows,
+                windows=N_WINDOWS,
                 min_ev=min_EV,
                 stake=FLAT_STAKE,
                 prob_clip_lo=PROB_CLIP_LO,
                 prob_clip_hi=PROB_CLIP_HI,
-                min_trades_per_window=min_trades_per_window,
-            )
+                min_trades_per_window=MIN_TRADES_PER_WINDOW,
+            ) if local_params else {"hits": 0, "details": [], "rows_eval": 0}
             global_eval = evaluate_strategy_stability(
                 df_past_sorted,
                 global_params,
-                windows=windows,
+                windows=N_WINDOWS,
                 min_ev=min_EV,
                 stake=FLAT_STAKE,
                 prob_clip_lo=PROB_CLIP_LO,
                 prob_clip_hi=PROB_CLIP_HI,
-                min_trades_per_window=min_trades_per_window,
-            )
-            compare_n = int(local_tail_used or 400)
-            global_compare, _ = evaluate_params_on_hist_window(
-                df_past_sorted.tail(compare_n),
-                global_params,
-                min_ev=min_EV,
-                flat_stake_backtest=FLAT_STAKE,
-                prob_clip_lo=PROB_CLIP_LO,
-                prob_clip_hi=PROB_CLIP_HI,
-            )
-            local_compare, _ = evaluate_params_on_hist_window(
-                df_past_sorted.tail(compare_n),
-                local_params,
-                min_ev=min_EV,
-                flat_stake_backtest=FLAT_STAKE,
-                prob_clip_lo=PROB_CLIP_LO,
-                prob_clip_hi=PROB_CLIP_HI,
-            )
+                min_trades_per_window=MIN_TRADES_PER_WINDOW,
+            ) if global_params else {"hits": 0, "details": [], "rows_eval": 0}
+            compare_n = max(N_WINDOWS)
+            global_compare = {"profit_€": 0.0, "roi_%": 0.0}
+            local_compare = {"profit_€": 0.0, "roi_%": 0.0}
+            if global_params:
+                global_compare, _ = evaluate_params_on_hist_window(
+                    df_past_sorted.tail(compare_n),
+                    global_params,
+                    min_ev=min_EV,
+                    flat_stake_backtest=FLAT_STAKE,
+                    prob_clip_lo=PROB_CLIP_LO,
+                    prob_clip_hi=PROB_CLIP_HI,
+                )
+            if local_params:
+                local_compare, _ = evaluate_params_on_hist_window(
+                    df_past_sorted.tail(compare_n),
+                    local_params,
+                    min_ev=min_EV,
+                    flat_stake_backtest=FLAT_STAKE,
+                    prob_clip_lo=PROB_CLIP_LO,
+                    prob_clip_hi=PROB_CLIP_HI,
+                )
             logging.info("=== [ROBUST++++] PROFIT/STABILITY EVAL (GLOBAL vs LOCAL) ===")
-            logging.info(
-                "Windows: %s | stability hits needed: %d | min trades per window: %d",
-                windows,
-                hits_needed,
-                min_trades_per_window,
-            )
+            logging.info("Windows: %s | stability hits needed: %d | min trades per window: %d", N_WINDOWS, STABILITY_HITS_NEEDED, MIN_TRADES_PER_WINDOW)
             logging.info("GLOBAL eval rows      : %d", int(global_eval["rows_eval"]))
             logging.info("LOCAL eval rows       : %d", int(local_eval["rows_eval"]))
             logging.info("LOCAL tail found      : %s", str(local_tail_used))
             logging.info("LOCAL tail evaluated  : %d", compare_n)
-            if local_eval["hits"] >= hits_needed and float(local_compare["profit_€"]) >= float(global_compare["profit_€"]):
-                logging.info("✅ FOUND PROFITABLE CONFIG")
+            local_pass = bool(local_params and local_eval["hits"] >= STABILITY_HITS_NEEDED)
+            global_pass = bool(global_params and global_eval["hits"] >= STABILITY_HITS_NEEDED)
+            if not local_pass and not global_pass:
+                local_params = None
+                no_bet_mode = True
+                logging.info("%s", {"chosen": "NO_BET", "compareN": compare_n})
+            elif local_pass and not global_pass:
                 logging.info("%s", {"chosen": "LOCAL", "compareN": compare_n})
-                logging.info("params: %s", local_params)
-            else:
+            elif global_pass and not local_pass:
                 local_params = dict(global_params)
-                logging.info("✅ FOUND PROFITABLE CONFIG")
                 logging.info("%s", {"chosen": "GLOBAL", "compareN": compare_n})
-                logging.info("params: %s", local_params)
+            else:
+                local_profit = float(local_compare.get("profit_€", 0.0))
+                global_profit = float(global_compare.get("profit_€", 0.0))
+                if (local_profit > global_profit) or (
+                    np.isclose(local_profit, global_profit)
+                    and float(local_compare.get("roi_%", 0.0)) >= float(global_compare.get("roi_%", 0.0))
+                ):
+                    logging.info("%s", {"chosen": "LOCAL", "compareN": compare_n})
+                else:
+                    local_params = dict(global_params)
+                    logging.info("%s", {"chosen": "GLOBAL", "compareN": compare_n})
 
     # fallback if search found nothing
     if not local_params:
-        if global_params:
+        if no_bet_mode:
+            local_params = {
+                "home_win_rate_threshold": 1.01,
+                "odds_min": 99.0,
+                "odds_max": 100.0,
+                "prob_threshold": 1.01,
+                "n_trades": 0,
+                "profit_€": 0.0,
+                "roi_%": 0.0,
+            }
+            logging.warning("NO_BET arbitration triggered; using impossible filter params to produce zero live bets.")
+        elif global_params:
             used_global_fallback = True
             local_params = dict(global_params)
             logging.warning("LOCAL param search returned None; using GLOBAL params fallback.")
@@ -2235,6 +2346,8 @@ def main() -> None:
         )
 
     # Minimal snapshot for trace (keep structure, but based on LOCAL params + last-200)
+    used_global_fallback = bool(locals().get("used_global_fallback", False))
+    used_safe_fallback = bool(locals().get("used_safe_fallback", False))
     fallback_used = bool(insufficient_history or used_global_fallback or used_safe_fallback)
     fallback_reason = (
         "skipped_insufficient_history"

--- a/2026/src/live_oos_proxy.py
+++ b/2026/src/live_oos_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict, is_dataclass
 from typing import Any
 
 import numpy as np
@@ -8,6 +9,28 @@ import pandas as pd
 
 DEFAULT_PROB_SOURCE_COLS = ["prob_iso_oos_time", "home_team_prob"]
 
+
+
+
+def _proxy_get(proxy_obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(proxy_obj, dict):
+        return proxy_obj.get(key, default)
+    if is_dataclass(proxy_obj):
+        return asdict(proxy_obj).get(key, default)
+    if hasattr(proxy_obj, key):
+        return getattr(proxy_obj, key)
+    getter = getattr(proxy_obj, "get", None)
+    if callable(getter):
+        try:
+            return getter(key, default)
+        except TypeError:
+            pass
+    return default
+
+
+def _proxy_has(proxy_obj: Any, key: str) -> bool:
+    sentinel = object()
+    return _proxy_get(proxy_obj, key, sentinel) is not sentinel
 
 def _wilson_lower_bound(wins: float, n: float, z: float = 1.96) -> float:
     if n <= 0:
@@ -127,12 +150,12 @@ def build_live_oos_proxy(
 
 def apply_live_oos_proxy(
     df_upcoming: pd.DataFrame,
-    proxy_obj: dict[str, Any],
+    proxy_obj: Any,
     in_col: str = "home_team_prob",
 ) -> pd.DataFrame:
     out = df_upcoming.copy()
-    ready = bool(proxy_obj.get("ready", False))
-    train_rows = int(proxy_obj.get("train_rows", 0))
+    ready = bool(_proxy_get(proxy_obj, "ready", False))
+    train_rows = int(_proxy_get(proxy_obj, "train_rows", 0) or 0)
 
     out["prob_live_oos_proxy"] = np.nan
     out["live_oos_proxy_ready"] = ready
@@ -140,11 +163,12 @@ def apply_live_oos_proxy(
     out["live_oos_proxy_bin_n"] = 0
     out["live_oos_proxy_bin_winrate"] = np.nan
 
-    if not ready or "predict_proxy" not in proxy_obj:
+    predict_fn = _proxy_get(proxy_obj, "predict_proxy")
+    if not ready or not callable(predict_fn) or not _proxy_has(proxy_obj, "predict_proxy"):
         return out
 
     p_in = pd.to_numeric(out.get(in_col), errors="coerce")
-    preds = p_in.apply(proxy_obj["predict_proxy"])
+    preds = p_in.apply(predict_fn)
     out["prob_live_oos_proxy"] = preds.apply(lambda x: x[0] if isinstance(x, tuple) else np.nan)
     out["live_oos_proxy_bin_n"] = preds.apply(lambda x: x[1] if isinstance(x, tuple) else 0).astype(int)
     out["live_oos_proxy_bin_winrate"] = preds.apply(lambda x: x[2] if isinstance(x, tuple) else np.nan)


### PR DESCRIPTION
### Motivation

- Improve robustness of local parameter selection by adding walk-forward coverage/stability checks, multiple scoring modes and a defensible "no-bet" fallback to avoid live betting when historical evidence is insufficient. 
- Make historical home-win rate computation and attachment more accurate by only using played home games and preserving missing values as `NaN` instead of zero. 
- Harden the live out-of-sample (OOS) proxy utilities to accept flexible proxy objects (dict, dataclass, or objects with attributes) and safer predicate extraction.

### Description

- Introduced many configuration knobs for walk-forward/backtesting behavior such as `LOCAL_TAIL_LADDER`, `WALK_TRAIN_MIN_DAYS`, `WALK_TEST_DAYS`, `WALK_STEP_DAYS`, `MIN_WALK_SPLITS`, `MIN_TEST_TRADES_TOTAL`, `MIN_ACTIVE_SPLITS`, `MIN_TRADES_PER_ACTIVE_SPLIT`, `MIN_TRADES_TRAIN`, `MIN_TRADES_PER_WINDOW`, `N_WINDOWS`, `STABILITY_HITS_NEEDED`, `USE_SOFT_GATE`, `SOFT_Q`, `MIN_Q_TRADES`, `SCORE_MODE`, and `LCB_K` and kept previous grids/constants. 
- Refined `compute_home_win_rates` to use only played home games (based on `RESULT_COL`), take the last 20 home games, compute integer wins safely, and return `NaN` when insufficient data; `attach_home_win_rate` now leaves missing rates as `NaN` and converts values with `pd.to_numeric` without forcing zeros. 
- Lowered the `min_trades_local` default in `find_best_local_params_lastN`, added a few extra summary metrics in returned `best_params`, and improved handling of numeric casts. 
- Rewrote `find_best_local_params_walk_forward` to perform date-based rolling walk-forward splits (instead of simple index folding), apply train/test trade minimums, compute per-split scores, support multiple `SCORE_MODE` strategies (including LCB-based scoring), enforce coverage gates (active splits, test trade totals, soft gate based on quantiles), and return richer candidate metadata. 
- Modified main local-parameter selection logic to iterate `LOCAL_TAIL_LADDER`, pick the best gated walk-forward candidate, evaluate stability across `N_WINDOWS`, prefer local/global based on `STABILITY_HITS_NEEDED` and profit/ROI tie-breakers, and enable a `no_bet_mode` that emits impossible filter parameters when neither local nor global passes stability checks. 
- In `live_oos_proxy.py` added helper functions `_proxy_get` and `_proxy_has` to extract keys from dicts, dataclasses or objects, accept `proxy_obj: Any` instead of a strict dict, and ensure `predict_proxy` is callable before applying it. 

### Testing

- Ran the project's unit test suite with `pytest` which included tests for `live_oos_proxy` and isotonic strategy helper functions, and all tests passed. 
- Executed integration/smoke runs of the local parameter search and live proxy application on a recent sample dataset to validate gating, no-bet behavior, and proxy predictions, and these smoke checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd44e5dfd48331bd4483578f961855)