### PR TITLE
Make script pause behavior non-blocking and add audit tests/spec

### DIFF
--- a/2026/src/1_get_data_previous_game_day_2026.py
+++ b/2026/src/1_get_data_previous_game_day_2026.py
@@ -22,6 +22,7 @@ Usage:
 """
 
 import os
+import sys
 import re
 import time
 import argparse
@@ -533,11 +534,13 @@ def process_saved_boxscores(
 
 def _pause_and_exit_ok():
     """
-    Local run: keep console window open.
-    In GitHub Actions: exit immediately (GITHUB_ACTIONS is 'true').
+    Never block by default.
+    Prompt only when explicitly requested in an interactive local terminal.
     """
     in_ci = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
-    if in_ci:
+    prompt_enabled = os.environ.get("ENABLE_EXIT_PROMPT", "").lower() == "true"
+    interactive_tty = sys.stdin.isatty()
+    if in_ci or not prompt_enabled or not interactive_tty:
         return
     try:
         input("Done. Press Enter to close this window...")

--- a/2026/src/2_get_data_next_game_day_2026.py
+++ b/2026/src/2_get_data_next_game_day_2026.py
@@ -206,16 +206,9 @@ def find_games_for_next_day(target_date: datetime, file_paths: List[str]) -> Lis
 
 def _pause_and_exit_ok():
     """
-    Keep window open if running locally.
-    In GitHub Actions, GITHUB_ACTIONS="true" so we just return.
+    Script 2 must never block for input in automation or local runs.
     """
-    in_ci = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
-    if in_ci:
-        return
-    try:
-        input("Done. Press Enter to close this window...")
-    except EOFError:
-        pass
+    return
 
 
 # ─────────────────────────────

--- a/2026/src/4_calculate_betting_statistics_2026.py
+++ b/2026/src/4_calculate_betting_statistics_2026.py
@@ -20,6 +20,7 @@ Then execute this script to compute betting statistics.
 
 import pandas as pd
 import os
+import sys
 import numpy as np
 import logging
 from datetime import timedelta
@@ -418,9 +419,11 @@ def main():
 if __name__ == "__main__":
     main()
 
-    # Don't prompt in GitHub Actions / CI
+    # Never block by default; prompt only when explicitly enabled locally.
     in_ci = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
-    if not in_ci:
+    prompt_enabled = os.environ.get("ENABLE_EXIT_PROMPT", "").lower() == "true"
+    interactive_tty = sys.stdin.isatty()
+    if not in_ci and prompt_enabled and interactive_tty:
         try:
             input("Press Enter to close this window...")
         except EOFError:

--- a/2026/tests/test_spec_gap_audit_improvements.py
+++ b/2026/tests/test_spec_gap_audit_improvements.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = REPO_ROOT / relative_path
+    src_dir = str(REPO_ROOT / "2026" / "src")
+    if src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_boxscore_html_validation_handles_blocked_and_valid_variants():
+    script1 = _load_module("script1_2026", "2026/src/1_get_data_previous_game_day_2026.py")
+
+    blocked_html = "<html><body>Please verify you are a human</body></html>"
+    valid_html = '<html><table id="line_score"></table><div>boxscore</div></html>'
+
+    assert script1.file_is_valid_html_boxscore(blocked_html) is False
+    assert script1.file_is_valid_html_boxscore(valid_html) is True
+
+
+def test_find_games_for_next_day_rolls_across_month_files(tmp_path: Path):
+    script2 = _load_module("script2_2026", "2026/src/2_get_data_next_game_day_2026.py")
+
+    month_1 = tmp_path / "october.html"
+    month_2 = tmp_path / "november.html"
+
+    month_1.write_text(
+        """
+        <table id="schedule">
+          <tr><th data-stat="date_game">Thu, Oct 30, 2025</th><td></td><td>Lakers</td><td></td><td>Celtics</td></tr>
+        </table>
+        """,
+        encoding="utf-8",
+    )
+
+    month_2.write_text(
+        """
+        <table id="schedule">
+          <tr><th data-stat="date_game">Sat, Nov 01, 2025</th><td></td><td>Knicks</td><td></td><td>Bulls</td></tr>
+          <tr><th data-stat="date_game">Sat, Nov 01, 2025</th><td></td><td>Heat</td><td></td><td>Nets</td></tr>
+          <tr><th data-stat="date_game">Sun, Nov 02, 2025</th><td></td><td>Suns</td><td></td><td>Warriors</td></tr>
+        </table>
+        """,
+        encoding="utf-8",
+    )
+
+    rows = script2.find_games_for_next_day(
+        target_date=datetime(2025, 10, 31),
+        file_paths=[str(month_1), str(month_2)],
+    )
+
+    assert len(rows) == 2
+    assert rows[0]["date"].strftime("%Y-%m-%d") == "2025-11-01"
+    assert {(r["visitor_team"], r["home_team"]) for r in rows} == {
+        ("Knicks", "Bulls"),
+        ("Heat", "Nets"),
+    }
+
+
+def test_fetch_odds_handles_partial_bookmaker_payload(monkeypatch):
+    os.environ.setdefault("ODDS_API_KEY", "dummy-test-key")
+    script3 = _load_module("script3_2026", "2026/src/3_predict_games_hybrid_2026.py")
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [
+                {
+                    "home_team": "Boston Celtics",
+                    "away_team": "New York Knicks",
+                    "bookmakers": [
+                        {
+                            "key": "draftkings",
+                            "markets": [
+                                {
+                                    "key": "h2h",
+                                    "outcomes": [
+                                        {"name": "Boston Celtics", "price": -140}
+                                        # away outcome intentionally missing
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+
+    class _FakeSession:
+        def get(self, *args, **kwargs):
+            return _FakeResponse()
+
+    monkeypatch.setattr(script3, "get_session", lambda: _FakeSession())
+
+    odds = script3.fetch_odds(
+        pd.DataFrame([{"home_team": "BOS", "away_team": "NYK"}]),
+        api_key="dummy-test-key",
+        preferred=["draftkings"],
+    )
+
+    assert list(odds.columns) == ["home_team", "away_team", "odds 1", "odds 2"]
+    assert len(odds) == 1
+    assert pd.isna(odds.loc[0, "odds 2"])

--- a/GAP_AUDIT_SPEC_2026.md
+++ b/GAP_AUDIT_SPEC_2026.md
@@ -1,0 +1,99 @@
+# SPEC Gap Audit (2026 Pipeline)
+
+Date: 2026-04-13  
+Scope: `SPEC.md` vs implemented behavior in scripts/modules/tests.
+
+## Method
+
+- Reviewed Script 1–5 implementations in `2026/src`.
+- Reviewed live modules: `live_probability_pipeline.py`, `live_oos_proxy.py`, `live_safety.py`.
+- Reviewed validation/test coverage in `2026/scripts`, `2026/tests`, and `tests`.
+- Ran repo verifiers and targeted tests.
+
+## Commands Run
+
+- `python 2026/scripts/verify_outputs.py`
+- `python 2026/scripts/verify_pipeline_consistency.py`
+- `pytest -q 2026/tests/test_live_safety.py tests/test_pipeline_outputs.py`
+
+## Script-by-Script Audit
+
+## 1) `1_get_data_previous_game_day_2026.py`
+**Status:** ✅ Mostly aligned
+
+- Implements schedule-page fetch, previous completed game-day collection, box-score retrieval, local-cache reuse, HTML validity checks, requests-first + Selenium fallback, and parsing logic resilient to Basketball-Reference quirks/comments.
+- Writes/updates daily historical snapshot and refreshed source HTML artifacts.
+
+## 2) `2_get_data_next_game_day_2026.py`
+**Status:** ✅ Aligned (updated)
+
+- Finds next game day on/after anchor date, checks subsequent months when needed, normalizes names to internal codes, writes expected CSV schema.
+- Empty-matchup day path writes header-only CSV for downstream stability.
+- **Updated in this patch:** exit pause is now a true no-op so Script 2 never blocks for interactive input.
+
+## 3) `3_predict_games_hybrid_2026.py`
+**Status:** ✅ Mostly aligned
+
+- Fails fast when `ODDS_API_KEY` is missing.
+- Supports fallback to latest `games_df_*.csv` when today's file is absent.
+- Includes team normalization/mapping (including PHX/CHA related mappings) prior to odds merge.
+- Produces daily prediction CSV with probability-chain placeholders expected downstream.
+
+## 4) `4_calculate_betting_statistics_2026.py`
+**Status:** ✅ Aligned
+
+- Rebuilds cumulative ACC snapshots and upserts by canonical game identity.
+- Dedup prefers row completeness and recency via scoring/sort.
+- Preserves normalized schema and writes dated cumulative artifact.
+
+## 5) `5_Isotonic_based_betting_strategy_2026.py`
+**Status:** ✅ Mostly aligned
+
+- Builds isotonic calibration + live/OOS probability chain.
+- Persists shortlist, strategy params, metrics snapshot, and local-matched artifacts (including latest aliases).
+- Applies safety guard behavior and keeps blocking metadata (`blocked_by`, market-gap flags) in outputs.
+
+## Live modules
+
+## `live_probability_pipeline.py`
+**Status:** ✅ Aligned
+
+- Loads active strategy params from snapshot/txt/override paths.
+- Enforces required params for strict callers.
+- Ensures downstream probability/safety columns exist.
+
+## `live_oos_proxy.py`
+**Status:** ✅ Aligned
+
+- Builds proxy from OOS-labeled data with fallback source handling.
+- Emits readiness + metadata fields for downstream/traceability.
+
+## `live_safety.py`
+**Status:** ✅ Aligned
+
+- Computes market-implied probabilities, applies guard logic, caps/shrink behavior, and final `prob_used`.
+- Emits `blocked_by` markers for market-gap guard outcomes.
+
+## Validation/Test Coverage Audit
+
+**Status:** ✅ Improved
+
+- Output/schema and consistency checks are implemented and passing.
+- Live safety unit coverage exists and passes.
+- Top-level pipeline output regression checks pass.
+- Added targeted deterministic tests for:
+  - blocked/garbled box-score HTML detection,
+  - next-game-day month rollover schedule parsing,
+  - partial/degenerate odds-bookmaker payload handling.
+
+## Summary of Gaps
+
+1. **Closed in this patch:** Script 2 interactive pause behavior tightened to hard non-blocking no-op.
+2. **Closed in this patch:** added deterministic tests for the scrape/API edge cases previously identified.
+3. **Remaining low-risk gap:** broaden integration-style fixtures for additional anti-bot/schedule/odds variants to further raise confidence.
+
+## Recommended Next Steps
+
+- Expand fixture corpus for additional anti-bot HTML signatures and malformed table structures.
+- Add more bookmaker payload permutations (multi-book fallback priority, missing team name mapping).
+- Keep `verify_outputs.py` and `verify_pipeline_consistency.py` in CI gates (already aligned with spec contracts).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,565 @@
+# Basketball Prediction Logic Specification (2026)
+
+## 1. Purpose
+
+This repository implements an end-to-end NBA data, prediction, calibration, and betting-automation pipeline for the 2026 season.
+
+The system’s goals are to:
+
+- collect historical NBA results and upcoming fixtures,
+- train a model to estimate home-team win probability,
+- calibrate and adjust probabilities for live betting,
+- generate a shortlist of qualifying bets,
+- maintain a settled bet ledger,
+- publish dashboard-ready artifacts.
+
+The repository is organized around a five-script daily pipeline plus dashboard and validation helpers.
+
+---
+
+## 2. High-Level Flow
+
+Canonical daily flow:
+
+1. Scrape previous game-day results.
+2. Scrape next game-day schedule.
+3. Train/predict next-day games with LightGBM and odds.
+4. Merge actual results into cumulative prediction history and compute betting statistics.
+5. Build isotonic-calibrated probabilities, apply live-safety logic, produce a shortlist, and update the bet ledger.
+
+Primary output tree:
+
+- `2026/output/LightGBM`
+- `2026/output/LightGBM/Kelly`
+- `web/public/data`
+
+---
+
+## 3. Core Data Domains
+
+### 3.1 Historical game statistics
+Produced by Script 1 and consumed by later scripts.
+
+Typical fields include:
+
+- `team`
+- `team_opp`
+- `date`
+- `season`
+- `won`
+- team stats, opponent-mirrored stats, and rolling-feature columns
+
+### 3.2 Upcoming games
+Produced by Script 2.
+
+Required fields:
+
+- `home_team`
+- `away_team`
+- `game_date`
+
+### 3.3 Combined prediction history
+Maintained by Scripts 3 and 4, enriched by Script 5.
+
+Canonical columns include:
+
+- `home_team`
+- `away_team`
+- `home_team_prob`
+- `odds_1`
+- `odds_2`
+- `result`
+- `date`
+- `accuracy`
+
+Probability-chain fields:
+
+- `prob_iso`
+- `prob_iso_insample`
+- `prob_iso_oos_time`
+- `prob_live_oos_proxy`
+- `prob_live_safe_pre_clip`
+- `prob_base`
+- `prob_live_safe`
+- `prob_used`
+
+### 3.4 Shortlist
+Script 5 emits a shortlist containing only bets that survive filtering and safety logic.
+
+Required fields:
+
+- `game_date`
+- `home_team`
+- `away_team`
+- `home_team_prob`
+- `prob_iso`
+- `prob_iso_oos_time`
+- `prob_live_oos_proxy`
+- `prob_live_safe_pre_clip`
+- `prob_base`
+- `prob_used`
+- `odds_1`
+- `market_implied_p_raw`
+- `market_implied_p_devig`
+- `model_market_gap`
+- `model_market_gap_flag`
+- `live_underdog_upscale_guard_triggered`
+- `live_shrink_triggered`
+- `live_oos_proxy_ready`
+- `live_oos_proxy_train_rows`
+- `live_oos_proxy_bin_n`
+- `live_oos_proxy_bin_winrate`
+- `blocked_by`
+- `home_win_rate`
+- `EV_€_per_100`
+
+### 3.5 Ledger
+The live bet ledger tracks settled bets, stake, outcome, and P&L.
+
+Core fields:
+
+- `date`
+- `home_team`
+- `away_team`
+- `stake`
+- `odds`
+- `pick`
+- `status`
+- `won`
+- `pnl`
+- `prob_used`
+- `prob_base`
+- `prob_live_oos_proxy`
+- `prob_live_safe_pre_clip`
+- `market_implied_p_raw`
+- `market_implied_p_devig`
+- `model_market_gap`
+- `model_market_gap_flag`
+- `live_underdog_upscale_guard_triggered`
+- `live_shrink_triggered`
+- `live_oos_proxy_ready`
+- `live_oos_proxy_train_rows`
+- `live_oos_proxy_bin_n`
+- `live_oos_proxy_bin_winrate`
+- `blocked_by`
+- `ev_per_100`
+- `created_at_utc`
+- `settled_at_utc`
+- `source`
+
+---
+
+## 4. Script-by-Script Specification
+
+### 4.1 Script 1: Previous game-day scrape
+**File:** `2026/src/1_get_data_previous_game_day_2026.py`
+
+Responsibilities:
+
+- fetch current-month NBA schedule page,
+- locate previous completed game day,
+- fetch each box-score HTML page,
+- validate HTML to reject anti-bot junk,
+- parse team box-score tables,
+- flatten and normalize stats,
+- append home/away rows to historical dataset,
+- save daily historical snapshot.
+
+Rules:
+
+- invalid/blocked HTML must not be persisted as box-score data,
+- parsing must tolerate Basketball-Reference table quirks and hidden comments,
+- valid local box scores should be reused,
+- invalid local copies should refresh via requests and then Selenium fallback.
+
+Outputs:
+
+- daily `nba_games_<DATE>.csv`,
+- updated schedule HTML in standings storage,
+- updated box-score HTML in scores storage.
+
+### 4.2 Script 2: Next game-day scrape
+**File:** `2026/src/2_get_data_next_game_day_2026.py`
+
+Responsibilities:
+
+- load schedule HTML for relevant month,
+- identify next game day on/after anchor date,
+- extract all matchups for that date,
+- normalize team names to internal 3-letter codes,
+- persist upcoming fixtures to CSV.
+
+Rules:
+
+- must never block waiting for user input,
+- if no games are found, still write empty CSV with correct schema,
+- if current month has no next game day, continue checking later months.
+
+Output:
+
+- `games_df_<DATE>.csv` in next-game directory.
+
+### 4.3 Script 3: Prediction and odds merge
+**File:** `2026/src/3_predict_games_hybrid_2026.py`
+
+Responsibilities:
+
+- load latest historical stats file,
+- construct rolling features,
+- scale features with MinMax scaling,
+- create next-game targets,
+- train LightGBM on historical data,
+- predict home-win probabilities for upcoming games,
+- fetch bookmaker odds from The Odds API,
+- merge predictions and odds into daily prediction file.
+
+Key rules:
+
+- `ODDS_API_KEY` must be present,
+- fail fast if odds key is missing,
+- normalize team names/abbreviations before odds lookup,
+- map Phoenix/Charlotte naming differences,
+- fallback to latest available games file if today’s file is missing.
+
+Outputs:
+
+- `nba_games_predict_<DATE>.csv`,
+- cumulative prediction artifacts for downstream steps.
+
+### 4.4 Script 4: Betting statistics and cumulative predictions
+**File:** `2026/src/4_calculate_betting_statistics_2026.py`
+
+Responsibilities:
+
+- load latest prediction file,
+- merge actual outcomes into historical prediction snapshots,
+- rebuild cumulative combined predictions file,
+- normalize combined schema,
+- preserve canonical column ordering,
+- update accuracy and derived metrics,
+- support deduped upsert behavior for game rows.
+
+Important logic:
+
+- game identity = `date + home_team + away_team`,
+- row completeness prefers more complete records in dedupe,
+- cumulative state can be reconstructed from prior snapshots.
+
+Outputs:
+
+- `combined_nba_predictions_acc_<DATE>.csv`,
+- related summaries and historical snapshots.
+
+### 4.5 Script 5: Calibration, safety, shortlist, and metrics
+**File:** `2026/src/5_Isotonic_based_betting_strategy_2026.py`
+
+Responsibilities:
+
+- load combined prediction history,
+- compute isotonic calibration,
+- build time-aware OOS probability chain,
+- build live OOS proxy,
+- apply market-aware safety guards,
+- run parameter search/strategy selection,
+- generate shortlist and local matched-game outputs,
+- write strategy parameters and metrics snapshots,
+- validate dashboard-ready artifact consistency.
+
+#### Probability chain semantics
+
+1. `home_team_prob` — raw LightGBM probability.
+2. `prob_iso` — in-sample isotonic reference probability.
+3. `prob_iso_oos_time` — time-aware OOS isotonic probability for played rows.
+4. `prob_live_oos_proxy` — live proxy from OOS-labeled history.
+5. `prob_live_safe_pre_clip` — pre-clip live-safe probability after market-gap guards/shrink.
+6. `prob_base` — EV-driving base probability.
+7. `prob_used` — final probability for EV and shortlist filters.
+
+#### Safety rules
+
+Safety layer applies:
+
+- clipping to bounded range,
+- market-implied probability computation,
+- underdog gap guard,
+- shrink logic for large model-market gaps,
+- hard blocking for strict market-gap violations.
+
+Strict guard rows must be marked:
+
+- `blocked_by = MODEL_MARKET_GAP`
+
+Outputs:
+
+- `combined_nba_predictions_iso_<DATE>.csv`
+- `bet_shortlist_<DATE>.csv`
+- `strategy_params.txt`
+- `strategy_params.json`
+- `metrics_snapshot.json`
+- `local_matched_games_<DATE>.csv`
+- `local_matched_games_latest.csv`
+
+---
+
+## 5. Live Probability Modules
+
+### 5.1 `live_probability_pipeline.py`
+
+Role:
+
+- orchestrates probability-chain transformation,
+- loads active strategy parameters from Script-5 outputs,
+- coordinates OOS isotonic calibration, live proxy generation, and safety filtering.
+
+Functions:
+
+- load active strategy params,
+- build chain configuration,
+- prepare live probability columns.
+
+Guarantee:
+
+- output dataframe contains all downstream probability/safety fields, even when some components are unavailable.
+
+### 5.2 `live_oos_proxy.py`
+
+Role:
+
+- estimate live probability proxy from historical OOS-labeled data,
+- bin probabilities into quantile buckets,
+- use Wilson lower bounds or smoothed rates,
+- optionally dedupe repeated games by date/home/away,
+- optionally blend proxy output with base probability.
+
+Required behavior:
+
+- mark proxy not ready when training data is insufficient,
+- record fallback when preferred source column is unavailable,
+- still emit metadata columns for upcoming rows when proxy is unavailable.
+
+Important emitted fields:
+
+- `ready`
+- `train_rows`
+- `global_win_rate`
+- `bin_edges`
+- `bin_n`
+- `bin_win_rate`
+- `source_col_used`
+- `fallback_used`
+- `fallback_reason`
+- `recent_window_used`
+
+### 5.3 `live_safety.py`
+
+Role:
+
+- compute market-implied probabilities,
+- compare model vs market probabilities,
+- apply underdog and gap guards,
+- blend model and market probabilities,
+- produce final `prob_used`,
+- decide whether a row is blocked.
+
+Important constants include:
+
+- clip bounds,
+- underdog odds threshold,
+- underdog probability threshold,
+- gap threshold,
+- underdog cap,
+- gap blend temperature.
+
+Behavior:
+
+- when `live_oos_proxy_ready` is true, base probability can come from proxy,
+- large positive model-market gaps can trigger block or cap,
+- `prob_used` is final probability for betting filters and EV.
+
+---
+
+## 6. Output and Dashboard Specification
+
+### 6.1 Output tree
+
+Main data products:
+
+- `2026/output/Gathering_Data`
+- `2026/output/LightGBM`
+- `2026/output/LightGBM/Kelly`
+- `2026/bet_log`
+- `web/public/data`
+
+### 6.2 Dashboard assets
+
+Dashboard builder copies or synthesizes:
+
+- `combined_latest.csv`
+- `local_matched_games_latest.csv`
+- `bet_log_flat_live.csv`
+- `metrics_snapshot.json`
+- `strategy_params.json`
+- `dashboard_state.json`
+
+Dashboard UI reads only from `web/public/data`.
+
+### 6.3 Dashboard state
+
+Dashboard state includes:
+
+- as-of date,
+- window size,
+- window start/end,
+- active filters text,
+- source file references,
+- bet-log freshness metadata,
+- strategy match count in current window.
+
+---
+
+## 7. Validation and Testing
+
+### 7.1 Output schema verification
+**Script:** `2026/scripts/verify_outputs.py`
+
+Checks:
+
+- latest ACC and ISO files exist,
+- ACC and ISO filenames match by date,
+- required columns exist,
+- headers are single-line and canonical,
+- shortlist exists with expected schema,
+- ledger exists and is not older than shortlist when shortlist has rows.
+
+### 7.2 Pipeline consistency verification
+**Script:** `2026/scripts/verify_pipeline_consistency.py`
+
+Checks:
+
+- probability-chain parity between Script 5 and ledger views,
+- required strategy parameters are discoverable,
+- missing required strategy parameters fail loudly,
+- fallback behavior without params is predictable.
+
+### 7.3 Live safety tests
+**File:** `2026/tests/test_live_safety.py`
+
+Coverage:
+
+- market-gap blocking,
+- underdog cap behavior,
+- OOS proxy readiness,
+- proxy-fill behavior for upcoming rows.
+
+### 7.4 Top-level pipeline regression test
+**File:** `tests/test_pipeline_outputs.py`
+
+Coverage:
+
+- ACC/ISO existence,
+- shortlist schema,
+- probability columns on played rows,
+- ledger recency.
+
+---
+
+## 8. Automation Specification
+
+### 8.1 GitHub Actions
+
+Workflow chain:
+
+1. collect previous-day results,
+2. collect next-game data,
+3. build predictions and betting lines,
+4. calculate betting statistics and shortlist,
+5. publish dashboard assets.
+
+CI also validates schemas and mirrors current data into dashboard-readable assets.
+
+### 8.2 Local wrappers
+
+Main wrapper: `master_run.sh`
+
+Purpose:
+
+- set `SOURCE_ROOT`,
+- set `LGBM_DIR`,
+- execute Scripts 1–5,
+- run pipeline output checks.
+
+Secondary wrapper: `run_pipeline.sh`
+
+Purpose:
+
+- validate required outputs exist,
+- derive date anchor from `metrics_snapshot.json`,
+- validate local matched-game exports,
+- build dashboard assets.
+
+---
+
+## 9. Configuration Rules
+
+### 9.1 Environment variables
+
+Important variables:
+
+- `SOURCE_ROOT`
+- `LGBM_DIR`
+- `N_WINDOW`
+- `STRATEGY_VARIANT`
+- `ODDS_API_KEY`
+- `STRATEGY_PARAMS_PATH`
+- `SEASON_YEAR`
+- `TARGET_DATE`
+
+### 9.2 Default strategy behavior
+
+- local default variant: `acc`,
+- CI may default to `iso` depending on workflow path,
+- probability clipping defaults to a conservative band,
+- historical local window defaults to 200 games.
+
+### 9.3 Strategy parameter sources
+
+Active strategy parameters can come from:
+
+1. `metrics_snapshot.json`
+2. `strategy_params.txt`
+3. `STRATEGY_PARAMS_PATH` override
+
+Missing required parameters should fail fast.
+
+---
+
+## 10. Canonical Invariants
+
+- canonical CSV headers are snake_case,
+- probability columns are always present in combined outputs,
+- shortlist files always exist (header-only is valid),
+- ledger rows deduplicate by game identity,
+- live proxy and live safety metadata persist,
+- dashboard assets always reflect latest eligible outputs,
+- pipeline does not mix simulated strategy metrics with settled real bets.
+
+---
+
+## 11. Operational Guarantees
+
+The system is designed for:
+
+- reproducible daily outputs,
+- auditable probability transformations,
+- strict market-aware blocking of risky rows,
+- separation of historical model performance from real ledger outcomes,
+- dashboard/CI consistency with generated artifacts.
+
+---
+
+## 12. Practical Notes
+
+- historical artifacts and generated outputs are operating state, not sample-only,
+- live proxy and safety layers are intentionally conservative and traceable,
+- missing/malformed upstream inputs should fail loudly,
+- some outputs (especially shortlist) may be empty by design when no bets pass filters.


### PR DESCRIPTION
### Motivation

- Prevent CI or automated runs from hanging on user prompts while still allowing an explicit interactive prompt when desired. 
- Improve resilience around scraping and odds-handling edge cases by adding deterministic tests. 
- Capture the intended pipeline behavior in a formal `SPEC.md` and record audit findings in `GAP_AUDIT_SPEC_2026.md`.

### Description

- Changed interactive-exit logic in `1_get_data_previous_game_day_2026.py` to never block by default and only prompt when `ENABLE_EXIT_PROMPT` is `true` and `sys.stdin.isatty()` is true, and added `import sys` for this check. 
- Made `2_get_data_next_game_day_2026.py` `_pause_and_exit_ok()` a hard no-op so Script 2 never blocks for input. 
- Updated `4_calculate_betting_statistics_2026.py` to gate the end-of-run prompt behind `ENABLE_EXIT_PROMPT` and an interactive TTY, and added `import sys`. 
- Added unit tests in `2026/tests/test_spec_gap_audit_improvements.py` covering blocked vs valid box-score HTML detection, month-rollover schedule parsing in `find_games_for_next_day`, and partial bookmaker payload handling in the odds fetcher. 
- Added `GAP_AUDIT_SPEC_2026.md` documenting the audit and `SPEC.md` as the pipeline specification for 2026.

### Testing

- Ran the new unit tests with `pytest -q 2026/tests/test_spec_gap_audit_improvements.py` and they passed. 
- Executed repository verification scripts `python 2026/scripts/verify_outputs.py` and `python 2026/scripts/verify_pipeline_consistency.py` as part of the audit and they completed without errors. 
- Existing CI-targeted tests such as `pytest -q 2026/tests/test_live_safety.py tests/test_pipeline_outputs.py` were run in the audit run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd541bd71083319a4085c1f8c1aa29)