### PR TITLE
Keep cached monthly schedule HTML as fallback instead of deleting stale copy

### DIFF
--- a/2026/src/1_get_data_previous_game_day_2026.py
+++ b/2026/src/1_get_data_previous_game_day_2026.py
@@ -158,13 +158,11 @@ def scrape_season_for_month(
     monthly_filename = f"NBA_{season}_games-{month_name}.html"
     monthly_path = os.path.join(standings_dir, monthly_filename)
 
-    # delete stale copy so we always refetch and don't trust old HTML
+    # Keep any existing local month file as a fallback.
+    # If the network fetch fails (e.g., rate limit / temporary block),
+    # main() will reuse this cached file.
     if os.path.exists(monthly_path):
-        try:
-            os.remove(monthly_path)
-            logging.info(f"Deleted outdated monthly file: {monthly_path}")
-        except Exception as e:
-            logging.error(f"Could not delete {monthly_path}: {e}")
+        logging.info(f"Cached monthly file already present: {monthly_path}")
 
     # 1. fetch season overview page: /leagues/NBA_2026_games.html
     season_url = f"https://www.basketball-reference.com/leagues/NBA_{season}_games.html"


### PR DESCRIPTION
### Motivation
- Avoid removing the local monthly HTML file so it can serve as a fallback when network fetches fail due to rate limiting or temporary outages.

### Description
- Stop deleting the existing monthly file in `scrape_season_for_month` and instead log that the cached file is present.
- Add a comment clarifying that the cached `NBA_{season}_games-{month_name}.html` will be reused by `main()` if fetching the remote page fails.
- Preserve the existing flow that fetches the season overview and resolves the monthly link.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d715d4c883318536eb017e8a9e3d)