### PR TITLE
fix(ci): rebase and retry push when 2026 branch is ahead

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -231,9 +231,15 @@ jobs:
           fi
 
           git commit -m "chore: update outputs (auto)"
+
           # Checkout may be detached (SHA-based), so push current HEAD explicitly to branch 2026.
-          git push origin HEAD:2026
+          # If remote moved ahead, rebase onto latest origin/2026 and retry.
+          if ! git push origin HEAD:2026; then
+            echo "Initial push rejected (likely non-fast-forward). Rebasing onto origin/2026 and retrying..."
+            git fetch origin 2026
+            git rebase origin/2026
+            git push origin HEAD:2026
+          fi
 
           
-
 


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by non-fast-forward rejections when the auto-commit step tries to push generated outputs to branch `2026` after the remote has advanced.

### Description
- Update `.github/workflows/4_calculate_betting_statistics_2026.yml` to attempt `git push origin HEAD:2026` and, on failure, run `git fetch origin 2026`, `git rebase origin/2026`, then retry `git push origin HEAD:2026`, preserving the detached-HEAD-safe push behavior and avoiding force-pushes.

### Testing
- Ran `git diff --check` with no whitespace or diff errors.
- Verified repository status with `git status --porcelain=v1 -b`.
- Inspected the modified workflow region with `nl -ba .github/workflows/4_calculate_betting_statistics_2026.yml | sed -n '226,255p'` and committed the change (commit `32429e2`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa631c9ac8331a2cd0309c9d07183)