### PR TITLE
Persist Script 11 watchlist history and harden Stage1 daily fallback

### DIFF
--- a/2026/scripts/betting_agent_stage1_snapshot.py
+++ b/2026/scripts/betting_agent_stage1_snapshot.py
@@ -20,9 +20,12 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _infer_latest_date(input_dir: Path) -> str:
+def _infer_latest_date(input_dir: Path, allow_combined_fallback: bool = False) -> str:
     dates: list[str] = []
-    for pattern in ["nba_games_predict_*.csv", "combined_nba_predictions_acc_*.csv"]:
+    patterns = ["nba_games_predict_*.csv"]
+    if allow_combined_fallback:
+        patterns.append("combined_nba_predictions_acc_*.csv")
+    for pattern in patterns:
         for path in input_dir.glob(pattern):
             m = DATE_PATTERN.search(path.name)
             if m:
@@ -67,7 +70,7 @@ def _load_csv_if_exists(path: Path) -> pd.DataFrame | None:
     return pd.read_csv(path)
 
 
-def build_snapshot(input_dir: Path, output_dir: Path, target_date: str) -> tuple[pd.DataFrame, dict[str, Any]]:
+def build_snapshot(input_dir: Path, output_dir: Path, target_date: str, allow_combined_fallback: bool = False) -> tuple[pd.DataFrame, dict[str, Any]]:
     daily_path = input_dir / f"nba_games_predict_{target_date}.csv"
     combined_path = input_dir / f"combined_nba_predictions_acc_{target_date}.csv"
     home_rates_path = input_dir / f"home_win_rates_sorted_{target_date}.csv"
@@ -91,8 +94,8 @@ def build_snapshot(input_dir: Path, output_dir: Path, target_date: str) -> tuple
 
     canonical_export_status, _ = _parse_local_report(local_report_path if local_report_path.exists() else None)
 
-    if df_daily is None and df_combined is None:
-        raise FileNotFoundError("No daily or combined prediction input found for target date")
+    if df_daily is None and (df_combined is None or not allow_combined_fallback):
+        raise FileNotFoundError("No daily prediction input found for target date")
 
     base = df_daily.copy() if df_daily is not None else df_combined.copy()
     base = _coalesce(
@@ -171,8 +174,14 @@ def build_snapshot(input_dir: Path, output_dir: Path, target_date: str) -> tuple
 
     base["canonical_export_status"] = canonical_export_status or ""
 
-    base["model_market_gap_flag"] = base.get("model_market_gap_flag", False).fillna(False).astype(bool)
-    base["blocked_by"] = base.get("blocked_by", "").fillna("")
+    if "model_market_gap_flag" in base.columns:
+        base["model_market_gap_flag"] = base["model_market_gap_flag"].fillna(False).astype(bool)
+    else:
+        base["model_market_gap_flag"] = False
+    if "blocked_by" in base.columns:
+        base["blocked_by"] = base["blocked_by"].fillna("")
+    else:
+        base["blocked_by"] = ""
 
     def classify(row: pd.Series) -> tuple[str, str, str]:
         if pd.isna(row.get("game_date")) or pd.isna(row.get("home_odds")) or pd.isna(row.get("away_odds")):
@@ -228,20 +237,40 @@ def main() -> None:
     parser.add_argument("--input-dir", default=str(LGBM_DIR))
     parser.add_argument("--output-dir", default=str(LGBM_DIR / "betting_agent_stage1"))
     parser.add_argument("--target-date", default=None)
+    parser.add_argument("--allow-combined-fallback", action="store_true")
     args = parser.parse_args()
 
     input_dir = Path(args.input_dir).resolve()
     output_dir = Path(args.output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
-    target_date = args.target_date or _infer_latest_date(input_dir)
+    target_date = args.target_date or _infer_latest_date(input_dir, allow_combined_fallback=args.allow_combined_fallback)
 
-    snapshot, manifest = build_snapshot(input_dir=input_dir, output_dir=output_dir, target_date=target_date)
+    daily_required_path = input_dir / f"nba_games_predict_{target_date}.csv"
+    if not daily_required_path.exists() and (args.target_date is not None or not args.allow_combined_fallback):
+        empty = pd.DataFrame(columns=["target_date","game_date","home_team","away_team"])
+        manifest = {"target_date": target_date, "created_utc": _utc_now_iso(), "input_dir": str(input_dir.resolve()), "output_dir": str(output_dir.resolve()), "files_found": {"daily_predictions": False}, "files_missing": ["daily_predictions"], "canonical_rows_found": 0, "daily_games_found": 0, "status": "data_incomplete_daily_predictions_missing"}
+        snapshot = empty
+    else:
+        snapshot, manifest = build_snapshot(input_dir=input_dir, output_dir=output_dir, target_date=target_date, allow_combined_fallback=args.allow_combined_fallback)
 
     csv_path = output_dir / f"stage1_daily_snapshot_{target_date}.csv"
     json_path = output_dir / f"stage1_daily_snapshot_{target_date}.json"
     manifest_path = output_dir / f"stage1_manifest_{target_date}.json"
 
     snapshot.to_csv(csv_path, index=False)
+
+    if "canonical_signal" not in snapshot.columns:
+        snapshot["canonical_signal"] = False
+    if "stage1_bucket" not in snapshot.columns:
+        snapshot["stage1_bucket"] = "DATA_INCOMPLETE"
+    if "allowed_review_type" not in snapshot.columns:
+        snapshot["allowed_review_type"] = "none"
+    if "home_prob_raw" not in snapshot.columns:
+        snapshot["home_prob_raw"] = pd.NA
+    if "home_odds" not in snapshot.columns:
+        snapshot["home_odds"] = pd.NA
+    if "away_odds" not in snapshot.columns:
+        snapshot["away_odds"] = pd.NA
 
     summary = {
         "games": int(len(snapshot)),

--- a/2026/scripts/persist_script11_watchlist_history.py
+++ b/2026/scripts/persist_script11_watchlist_history.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_frame(rows_df: pd.DataFrame, run_date: str, source: str | None) -> pd.DataFrame:
+    df = rows_df.copy()
+    rename = {"date": "game_date", "odds 1": "odds_1", "odds 2": "odds_2"}
+    df = df.rename(columns={k: v for k, v in rename.items() if k in df.columns})
+
+    for col in ["game_date", "home_team", "away_team", "blocked_by"]:
+        if col not in df.columns:
+            df[col] = ""
+    df["blocked_by"] = df["blocked_by"].fillna("").astype(str)
+    df["run_date"] = run_date
+    df["created_utc"] = _utc_now_iso()
+    if source is not None:
+        df["engine_state"] = source
+
+    df["game_key"] = (
+        df["game_date"].astype(str) + "__" + df["home_team"].astype(str) + "__" + df["away_team"].astype(str)
+    )
+    return df
+
+
+def classify_script11_row(row: pd.Series) -> str:
+    blocked = str(row.get("blocked_by", ""))
+
+    if "DATA_INCOMPLETE" in blocked:
+        return "DATA_INCOMPLETE"
+
+    if row.get("rules_passed", 0) >= 4 and row.get("EV_€_per_100", -999) > 0:
+        return "CANONICAL_MODEL_SIGNAL"
+
+    if (
+        row.get("home_win_rate", 0) >= 0.50
+        and row.get("odds_1", 0) >= 1.30
+        and row.get("odds_1", 0) <= 1.70
+        and row.get("prob_used", 0) >= 0.55
+        and row.get("EV_€_per_100", 999) <= 0
+        and "MODEL_MARKET_GAP" not in blocked
+    ):
+        return "LOW_PRICE_NEGATIVE_EV"
+
+    if (
+        row.get("home_win_rate", 0) >= 0.60
+        and row.get("odds_1", 0) >= 2.00
+        and row.get("odds_1", 0) <= 2.80
+        and row.get("prob_base", 0) >= 0.60
+        and "MODEL_MARKET_GAP" in blocked
+        and row.get("prob_used", 1) < 0.55
+    ):
+        return "RAW_MODEL_MARKET_GAP_HOME_DOG"
+
+    if "MODEL_MARKET_GAP" in blocked:
+        return "LIVE_WATCH_ONLY"
+
+    if row.get("EV_€_per_100", 999) <= 0:
+        return "NO_VALUE_SKIP"
+
+    return "LIVE_WATCH_ONLY"
+
+
+def _reconcile_outcomes(history: pd.DataFrame, combined_predictions_path: str | Path | None) -> pd.DataFrame:
+    if combined_predictions_path is None:
+        return history
+    path = Path(combined_predictions_path)
+    if not path.exists():
+        return history
+    combined = pd.read_csv(path)
+    if "date" in combined.columns and "game_date" not in combined.columns:
+        combined = combined.rename(columns={"date": "game_date"})
+    need = {"game_date", "home_team", "away_team"}
+    if not need.issubset(combined.columns):
+        return history
+
+    cols = [c for c in ["game_date", "home_team", "away_team", "result", "result_raw", "home_team_won"] if c in combined.columns]
+    outcomes = combined[cols].drop_duplicates(subset=["game_date", "home_team", "away_team"], keep="last")
+    merged = history.merge(outcomes, on=["game_date", "home_team", "away_team"], how="left", suffixes=("", "_c"))
+
+    for col in ["result", "result_raw", "home_team_won"]:
+        cc = f"{col}_c"
+        if cc in merged.columns:
+            merged[col] = merged.get(col).where(merged.get(col).notna(), merged[cc])
+            merged = merged.drop(columns=[cc])
+
+    result = merged.get("result", "").fillna("").astype(str)
+    home = merged["home_team"].astype(str)
+    away = merged["away_team"].astype(str)
+    settled = result.isin(home) | result.isin(away)
+    merged["settled"] = settled
+
+    if "home_team_won" not in merged.columns:
+        merged["home_team_won"] = pd.NA
+    merged.loc[settled & (result == home), "home_team_won"] = 1
+    merged.loc[settled & (result == away), "home_team_won"] = 0
+    merged["home_team_won"] = pd.to_numeric(merged["home_team_won"], errors="coerce")
+
+    odds = pd.to_numeric(merged.get("odds_1"), errors="coerce")
+    merged["pnl_ml_100"] = pd.NA
+    merged.loc[merged["home_team_won"] == 1, "pnl_ml_100"] = (odds - 1.0) * 100.0
+    merged.loc[merged["home_team_won"] == 0, "pnl_ml_100"] = -100.0
+    return merged
+
+
+def persist_script11_watchlist_history(rows_df: pd.DataFrame, output_dir: str | Path, run_date: str, params_used: dict[str, Any] | None = None, chosen: Any = None, compareN: Any = None, combined_predictions_path: str | Path | None = None, source: str | None = None) -> pd.DataFrame:
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    normalized = _normalize_frame(rows_df, run_date=run_date, source=source)
+
+    normalized["stage2_candidate_type"] = normalized.apply(classify_script11_row, axis=1)
+    normalized["params_chosen"] = chosen
+    normalized["params_compareN"] = compareN
+    normalized["params_used"] = "" if params_used is None else str(params_used)
+
+    history_path = out_dir / "script11_watchlist_history.csv"
+    if history_path.exists():
+        prior = pd.read_csv(history_path)
+        merged = pd.concat([prior, normalized], ignore_index=True, sort=False)
+    else:
+        merged = normalized.copy()
+
+    merged = merged.drop_duplicates(subset=["game_key", "run_date"], keep="last")
+    merged = _reconcile_outcomes(merged, combined_predictions_path)
+    merged = merged.sort_values(["game_date", "home_team", "away_team", "created_utc"], kind="stable")
+
+    dated_path = out_dir / f"script11_watchlist_history_{run_date}.csv"
+    latest_path = out_dir / "script11_watchlist_history_latest.csv"
+
+    merged.to_csv(history_path, index=False)
+    merged.loc[merged["run_date"].astype(str) == str(run_date)].to_csv(dated_path, index=False)
+    merged.loc[merged["run_date"].astype(str) == str(run_date)].to_csv(latest_path, index=False)
+    return merged

--- a/2026/tests/test_script11_watchlist_history.py
+++ b/2026/tests/test_script11_watchlist_history.py
@@ -1,0 +1,41 @@
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "persist_script11_watchlist_history.py"
+spec = importlib.util.spec_from_file_location("persist_script11_watchlist_history", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(mod)
+
+
+def test_upsert_and_classify_and_reconcile(tmp_path):
+    out = tmp_path / "LightGBM"
+    out.mkdir(parents=True)
+    run_date = "2026-05-01"
+    rows = pd.DataFrame([
+        {"game_date": run_date, "home_team": "ORL", "away_team": "DET", "home_win_rate": 0.78, "odds_1": 2.36, "prob_base": 0.622, "prob_used": 0.421, "blocked_by": "MODEL_MARKET_GAP | Prob<0.55 | EV<=0.00", "EV_€_per_100": -2},
+        {"game_date": run_date, "home_team": "HOU", "away_team": "LAL", "home_win_rate": 0.73, "odds_1": 1.59, "prob_used": 0.577, "blocked_by": "EV<=0.00", "EV_€_per_100": -1},
+    ])
+    combined = pd.DataFrame([
+        {"game_date": run_date, "home_team": "ORL", "away_team": "DET", "result": "ORL"},
+        {"game_date": run_date, "home_team": "HOU", "away_team": "LAL", "result": "LAL"},
+    ])
+    cpath = out / f"combined_nba_predictions_acc_{run_date}.csv"
+    combined.to_csv(cpath, index=False)
+
+    first = mod.persist_script11_watchlist_history(rows, out, run_date, combined_predictions_path=cpath, source="watchlist")
+    second = mod.persist_script11_watchlist_history(rows, out, run_date, combined_predictions_path=cpath, source="watchlist")
+
+    assert len(first) == 2
+    assert len(second) == 2
+    orl = second[second.home_team == "ORL"].iloc[0]
+    hou = second[second.home_team == "HOU"].iloc[0]
+    assert "MODEL_MARKET_GAP | Prob<0.55" in orl.blocked_by
+    assert orl.stage2_candidate_type in {"RAW_MODEL_MARKET_GAP_HOME_DOG", "LIVE_WATCH_ONLY"}
+    assert hou.stage2_candidate_type == "LOW_PRICE_NEGATIVE_EV"
+    assert orl.home_team_won == 1
+    assert hou.home_team_won == 0
+    assert float(orl.pnl_ml_100) == (2.36 - 1.0) * 100.0
+    assert float(hou.pnl_ml_100) == -100.0

--- a/2026/tests/test_stage1_daily_fallback.py
+++ b/2026/tests/test_stage1_daily_fallback.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "betting_agent_stage1_snapshot.py"
+
+
+def test_missing_daily_file_writes_data_incomplete(tmp_path):
+    inp = tmp_path / "LightGBM"
+    out = inp / "betting_agent_stage1"
+    inp.mkdir(parents=True)
+    pd.DataFrame([{"game_date": "2026-05-01", "home_team": "A", "away_team": "B"}]).to_csv(
+        inp / "combined_nba_predictions_acc_2026-05-01.csv", index=False
+    )
+    subprocess.check_call([sys.executable, str(SCRIPT), "--input-dir", str(inp), "--output-dir", str(out), "--target-date", "2026-05-01"])
+    manifest = json.loads((out / "stage1_manifest_2026-05-01.json").read_text())
+    snap = pd.read_csv(out / "stage1_daily_snapshot_2026-05-01.csv")
+    assert manifest["status"] == "data_incomplete_daily_predictions_missing"
+    assert manifest["daily_games_found"] == 0
+    assert snap.empty
+
+
+def test_daily_file_preferred(tmp_path):
+    inp = tmp_path / "LightGBM"
+    out = inp / "betting_agent_stage1"
+    inp.mkdir(parents=True)
+    daily = pd.DataFrame([
+        {"game_date": "2026-05-01", "home_team": "A", "away_team": "B", "odds_1": 2.1, "odds_2": 1.8, "home_team_prob": 0.55},
+        {"game_date": "2026-05-01", "home_team": "C", "away_team": "D", "odds_1": 2.2, "odds_2": 1.7, "home_team_prob": 0.52},
+        {"game_date": "2026-05-01", "home_team": "E", "away_team": "F", "odds_1": 1.9, "odds_2": 1.9, "home_team_prob": 0.51},
+    ])
+    daily.to_csv(inp / "nba_games_predict_2026-05-01.csv", index=False)
+    subprocess.check_call([sys.executable, str(SCRIPT), "--input-dir", str(inp), "--output-dir", str(out), "--target-date", "2026-05-01"])
+    snap = pd.read_csv(out / "stage1_daily_snapshot_2026-05-01.csv")
+    assert len(snap) == 3


### PR DESCRIPTION
### Motivation
- Preserve the real Script 11 live/watchlist decision state (live/shrink/blocked_by/EV/prob_used/etc.) so Stage 2 backtests can filter true live signals instead of relying on incomplete combined prediction proxies.
- Ensure runs are idempotent and do not duplicate rows on reruns by upserting history using a stable `game_key + run_date` key.
- Prevent Stage 1 from falling back to the full combined history by default when the daily `nba_games_predict_YYYY-MM-DD.csv` file is missing, which previously produced 1900+ row stale daily snapshots.

### Description
- Add `2026/scripts/persist_script11_watchlist_history.py` implementing `persist_script11_watchlist_history(...)` that normalizes Script 11 frames, builds a stable `game_key`, classifies rows into `stage2_candidate_type`, attaches params metadata, upserts into `script11_watchlist_history.csv`, writes dated and latest snapshots, and reconciles outcomes from the combined predictions file (`result`, `home_team_won`, `pnl_ml_100`).
- Harden `2026/scripts/betting_agent_stage1_snapshot.py` to: require the daily `nba_games_predict_<date>.csv` when `--target-date` is explicitly provided, default date inference to daily files only, add `--allow-combined-fallback` as an opt-in flag, and write a manifest with status `data_incomplete_daily_predictions_missing` plus an empty snapshot when the daily file is missing.
- Add tests: `2026/tests/test_script11_watchlist_history.py` to validate upsert, blocked_by preservation, classification, reconciliation and `pnl_ml_100` computation; and `2026/tests/test_stage1_daily_fallback.py` to validate Stage 1 missing-daily handling and preferred daily-file behavior.
- Note: the notebook integration point (`2026/_5_alt_isotonic_calibrated_betting_engine_v2.ipynb`) was not present in this checkout so the helper was not inserted there in this patch.

### Testing
- Ran the focused test suite with `pytest -q 2026/tests/test_script11_watchlist_history.py 2026/tests/test_stage1_daily_fallback.py` and all tests passed: `3 passed`.
- Tests exercise upsert/no-duplicate behavior, `blocked_by` string preservation, `MODEL_MARKET_GAP` classification via contains logic, outcome reconciliation to set `home_team_won` and `pnl_ml_100`, and Stage 1 fallback behavior when daily files are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a03bf32c83318c2efdf2ff8e0050)