### PR TITLE
Persist Script11 watchlist history and include outputs in CI commits

### DIFF
--- a/.github/workflows/4_calculate_betting_statistics_2026.yml
+++ b/.github/workflows/4_calculate_betting_statistics_2026.yml
@@ -231,12 +231,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          ls -la 2026/output/LightGBM/script11_watchlist_history* || true
+          git status --porcelain 2026/output/LightGBM/script11_watchlist_history* || true
+
           # Stage outputs
           git add -A 2026/output/LightGBM || true
           git add 2026/output/LightGBM/betting_agent_stage1 || true
 
           # Force-add dashboard assets even if ignored
           git add -f web/public/data || true
+          git add -f 2026/output/LightGBM/script11_watchlist_history*.csv || true
+          git add -f 2026/output/LightGBM/script11_watchlist_history_summary*.json || true
 
           # Optional safety: don't accidentally commit an unwanted folder
           git restore --staged 2026/LightGBM 2>/dev/null || true

--- a/2026/src/5_Isotonic_based_betting_strategy_2026.py
+++ b/2026/src/5_Isotonic_based_betting_strategy_2026.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import os
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -28,6 +29,19 @@ from sklearn.isotonic import IsotonicRegression
 from sklearn.metrics import brier_score_loss, log_loss
 
 from live_probability_pipeline import build_probability_chain_config, prepare_live_probability_columns
+
+
+
+# Allow importing helper from 2026/scripts. "2026" is not a valid Python package name.
+SCRIPT_HELPER_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_HELPER_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_HELPER_DIR))
+
+try:
+    from persist_script11_watchlist_history import persist_script11_watchlist_history
+except Exception as exc:
+    persist_script11_watchlist_history = None
+    logging.warning("Could not import persist_script11_watchlist_history: %s", exc)
 
 from nba_utils_2026 import (
     get_current_date,
@@ -241,6 +255,137 @@ def ensure_probability_columns(df: pd.DataFrame) -> pd.DataFrame:
     return out
 
 
+
+
+def _prepare_enriched_script11_frame_for_history(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+
+    # Normalize common aliases without overwriting existing enriched columns.
+    alias_pairs = {
+        "game_date": ["date"],
+        "odds_1": ["odds 1", "home_odds", "closing_home_odds"],
+        "odds_2": ["odds 2", "away_odds", "closing_away_odds"],
+        "home_team_prob": ["pred_home_win_proba", "home_prob_raw"],
+        "EV_€_per_100": ["EV_live_€_per_100", "home_ev_prob_used_per_100", "home_ev_raw_per_100"],
+    }
+
+    for target, candidates in alias_pairs.items():
+        if target not in out.columns:
+            for candidate in candidates:
+                if candidate in out.columns:
+                    out[target] = out[candidate]
+                    break
+
+    if "blocked_by" not in out.columns:
+        out["blocked_by"] = ""
+    out["blocked_by"] = out["blocked_by"].fillna("").astype(str)
+
+    if "model_market_gap_flag" not in out.columns:
+        out["model_market_gap_flag"] = out["blocked_by"].str.contains("MODEL_MARKET_GAP", na=False)
+
+    return out
+
+
+def _has_script11_enrichment(df: pd.DataFrame) -> tuple[bool, list[str]]:
+    if df is None or df.empty:
+        return False, ["empty dataframe"]
+
+    required = [
+        "home_team",
+        "away_team",
+        "odds_1",
+        "prob_base",
+        "prob_used",
+        "blocked_by",
+        "home_win_rate",
+    ]
+
+    ev_candidates = ["EV_€_per_100", "EV_live_€_per_100", "EV_base_€_per_100", "home_ev_prob_used_per_100"]
+    market_gap_candidates = ["model_market_gap", "model_market_gap_flag"]
+
+    missing = [c for c in required if c not in df.columns]
+    if not any(c in df.columns for c in ev_candidates):
+        missing.append("one of EV_€_per_100 / EV_live_€_per_100 / EV_base_€_per_100 / home_ev_prob_used_per_100")
+
+    if not any(c in df.columns for c in market_gap_candidates) and "MODEL_MARKET_GAP" not in " ".join(df.get("blocked_by", pd.Series(dtype=str)).astype(str).tolist()):
+        missing.append("model_market_gap/model_market_gap_flag or blocked_by containing MODEL_MARKET_GAP")
+
+    if missing:
+        return False, missing
+
+    nonnull_checks = {
+        "prob_base": df["prob_base"].notna().any(),
+        "prob_used": df["prob_used"].notna().any(),
+        "home_win_rate": df["home_win_rate"].notna().any(),
+        "odds_1": df["odds_1"].notna().any(),
+    }
+
+    ev_nonnull = any(c in df.columns and df[c].notna().any() for c in ev_candidates)
+
+    missing_nonnull = [k for k, ok in nonnull_checks.items() if not ok]
+    if not ev_nonnull:
+        missing_nonnull.append("non-null EV column")
+
+    if missing_nonnull:
+        return False, missing_nonnull
+
+    return True, []
+
+
+
+
+def _log_script11_history_candidate(name: str, source: str, df: pd.DataFrame, ok: bool, missing: list[str]) -> None:
+    if df is None:
+        logging.info("[Script11 history] candidate=%s source=%s is None ok=%s missing=%s", name, source, ok, missing)
+        return
+
+    key_cols = [
+        "prob_base", "prob_used", "blocked_by", "home_win_rate", "odds_1",
+        "model_market_gap", "model_market_gap_flag", "EV_€_per_100", "EV_live_€_per_100",
+        "EV_base_€_per_100", "rules_passed", "margin_hw", "margin_odds", "margin_prob", "margin_ev",
+    ]
+
+    nonnull = {}
+    for c in key_cols:
+        if c not in df.columns:
+            nonnull[c] = None
+            continue
+        if c in {"blocked_by", "rules_passed"}:
+            nonnull[c] = int(df[c].astype(str).str.len().gt(0).sum())
+        else:
+            nonnull[c] = int(pd.to_numeric(df[c], errors="coerce").notna().sum())
+
+    logging.info(
+        "[Script11 history] candidate=%s source=%s rows=%d cols=%d ok=%s missing=%s first_cols=%s",
+        name,
+        source,
+        int(len(df)),
+        int(len(df.columns)),
+        bool(ok),
+        missing,
+        list(df.columns[:5]),
+    )
+    logging.info("[Script11 history] candidate=%s source=%s key_nonnull=%s", name, source, nonnull)
+
+
+def _log_script11_history_outputs(output_dir: Path) -> None:
+    tracked = [
+        "script11_watchlist_history.csv",
+        "script11_watchlist_history_latest.csv",
+        "script11_watchlist_history_summary_latest.json",
+    ]
+    for fname in tracked:
+        fpath = Path(output_dir) / fname
+        if fpath.exists():
+            stat = fpath.stat()
+            logging.info(
+                "[Script11 history] output=%s exists=yes size=%d mtime=%s",
+                str(fpath),
+                int(stat.st_size),
+                datetime.fromtimestamp(stat.st_mtime).isoformat(),
+            )
+        else:
+            logging.info("[Script11 history] output=%s exists=no", str(fpath))
 def _extract_date_from_filename(filename: str, prefix: str) -> Optional[str]:
     if not filename.startswith(prefix) or not filename.endswith(".csv"):
         return None
@@ -2330,6 +2475,117 @@ def main() -> None:
         int(len(historical_subset_for_export)),
         int(len(matched_export_latest)),
     )
+
+
+    # --- Persist enriched Script 11 watchlist history ---
+    if persist_script11_watchlist_history is None:
+        logging.info("Skipping Script 11 history persistence: helper unavailable.")
+    else:
+        try:
+            combined_path_for_history = Path(pred_dir) / f"combined_nba_predictions_acc_{requested_ymd}.csv"
+
+            frames_to_persist = []
+
+            if "df_all" in locals() and isinstance(df_all, pd.DataFrame) and not df_all.empty:
+                unplayed_mask = df_all[RESULT_RAW_COL].isna() | (df_all[RESULT_RAW_COL].astype(str) == "0")
+                future_pool = df_all.loc[unplayed_mask].copy()
+                if not future_pool.empty:
+                    future_pool_for_history = _prepare_enriched_script11_frame_for_history(future_pool)
+                    ok, missing = _has_script11_enrichment(future_pool_for_history)
+                    _log_script11_history_candidate("future_pool_enriched", "watchlist", future_pool_for_history, ok, missing)
+                    if ok:
+                        frames_to_persist.append(("watchlist", future_pool_for_history))
+                    else:
+                        logging.info(
+                            "Skipping Script 11 history for enriched unplayed pool: enrichment missing: %s",
+                            missing,
+                        )
+
+            if "df_future" in locals() and isinstance(df_future, pd.DataFrame) and not df_future.empty:
+                future_for_history = _prepare_enriched_script11_frame_for_history(df_future)
+                ok, missing = _has_script11_enrichment(future_for_history)
+                _log_script11_history_candidate("df_future", "upcoming_d", future_for_history, ok, missing)
+                if ok:
+                    frames_to_persist.append(("upcoming_d", future_for_history))
+                else:
+                    logging.info(
+                        "Skipping Script 11 history for df_future: enrichment missing: %s",
+                        missing,
+                    )
+
+            for candidate_name in ("df_w", "watchlist", "df_watchlist", "watchlist_df"):
+                if candidate_name in locals() and isinstance(locals()[candidate_name], pd.DataFrame) and not locals()[candidate_name].empty:
+                    candidate_df = _prepare_enriched_script11_frame_for_history(locals()[candidate_name])
+                    ok, missing = _has_script11_enrichment(candidate_df)
+                    _log_script11_history_candidate(candidate_name, "watchlist", candidate_df, ok, missing)
+                    if ok:
+                        frames_to_persist.append(("watchlist", candidate_df))
+                    else:
+                        logging.info(
+                            "Skipping Script 11 history for %s: enrichment missing: %s",
+                            candidate_name,
+                            missing,
+                        )
+
+            if not any(source == "watchlist" for source, _ in frames_to_persist):
+                if "shortlist" in locals() and isinstance(shortlist, pd.DataFrame) and not shortlist.empty:
+                    shortlist_for_history = _prepare_enriched_script11_frame_for_history(shortlist)
+                    ok, missing = _has_script11_enrichment(shortlist_for_history)
+                    _log_script11_history_candidate("shortlist", "watchlist", shortlist_for_history, ok, missing)
+                    if ok:
+                        frames_to_persist.append(("watchlist", shortlist_for_history))
+                    else:
+                        logging.info(
+                            "Shortlist exists but is not enriched enough for Script 11 history: %s",
+                            missing,
+                        )
+
+            if not frames_to_persist:
+                logging.warning(
+                    "No enriched Script 11 frames were persisted. Move the persistence block later if this is unexpected."
+                )
+                logging.info("Script 11 history persistence candidates checked: df_all_unplayed, df_future, df_w/watchlist aliases, shortlist")
+
+            for source_name, frame in frames_to_persist:
+                key_cols = ["prob_base", "prob_used", "blocked_by", "home_win_rate", "odds_1", "model_market_gap", "model_market_gap_flag", "EV_€_per_100", "EV_live_€_per_100", "EV_base_€_per_100", "rules_passed", "margin_hw", "margin_odds", "margin_prob", "margin_ev"]
+                key_nonnull = {}
+                for c in key_cols:
+                    if c not in frame.columns:
+                        key_nonnull[c] = None
+                    elif c in {"blocked_by", "rules_passed"}:
+                        key_nonnull[c] = int(frame[c].astype(str).str.len().gt(0).sum())
+                    else:
+                        key_nonnull[c] = int(pd.to_numeric(frame[c], errors="coerce").notna().sum())
+                logging.info(
+                    "[Script11 history] persisting source=%s shape=%s output_dir=%s combined_path=%s first_cols=%s key_nonnull=%s",
+                    source_name,
+                    frame.shape,
+                    str(out_dir),
+                    str(combined_path_for_history),
+                    list(frame.columns[:5]),
+                    key_nonnull,
+                )
+                _log_script11_history_outputs(out_dir)
+                persisted = persist_script11_watchlist_history(
+                    rows_df=frame.copy(),
+                    output_dir=out_dir,
+                    run_date=requested_ymd,
+                    params_used=params_for_eval if "params_for_eval" in locals() else None,
+                    chosen=selection_decision if "selection_decision" in locals() else None,
+                    compareN=int(max(N_WINDOWS)) if "N_WINDOWS" in globals() and N_WINDOWS else None,
+                    combined_predictions_path=str(combined_path_for_history),
+                    source=source_name,
+                )
+                logging.info(
+                    "Persisted Script 11 history source=%s input_rows=%d total_rows=%d",
+                    source_name,
+                    len(frame),
+                    len(persisted),
+                )
+                _log_script11_history_outputs(out_dir)
+
+        except Exception as exc:
+            logging.warning("Script 11 history persistence failed: %s", exc)
 
     # Bankroll over last-200 window (model EV, same style)
     last_200_games = hist_window_200.copy()


### PR DESCRIPTION
### Motivation
- Persist enriched Script 11 watchlist/watchlist-like frames (CSV/JSON) from the isotonic betting strategy run so historical watchlist data can be stored and inspected.
- Ensure the GitHub Actions commit step includes the generated `script11_watchlist_history*` artifacts so they are pushed alongside other outputs.
- Make persistence robust to different runtime environments by allowing an optional helper import and failing gracefully when unavailable.

### Description
- Add import plumbing to `5_Isotonic_based_betting_strategy_2026.py` to include helpers from `2026/scripts` by inserting the directory on `sys.path` and attempt to import `persist_script11_watchlist_history` with a graceful fallback and logged warning.
- Implement enrichment, validation, and logging helpers: `_prepare_enriched_script11_frame_for_history`, `_has_script11_enrichment`, `_log_script11_history_candidate`, and `_log_script11_history_outputs` and integrate a persistence block in `main()` that collects candidate frames (unplayed `df_all`, `df_future`, `df_w`/`watchlist` aliases, and `shortlist`), validates enrichment, and calls `persist_script11_watchlist_history` when available.
- Add instrumentation and safety logs around persistence and include checks to avoid persisting insufficiently enriched frames, with exceptions caught and logged to avoid breaking the main run.
- Update the CI workflow `4_calculate_betting_statistics_2026.yml` to list and show status of `script11_watchlist_history*` files before committing and to force-add `script11_watchlist_history*.csv` and `script11_watchlist_history_summary*.json` into the commit.

### Testing
- No automated tests were added for the new persistence path and no automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ceb38ce4833185ed34a781767b55)